### PR TITLE
Feature/126

### DIFF
--- a/data/characters/amaru.json
+++ b/data/characters/amaru.json
@@ -242,5 +242,5 @@
   "updatedAt": "2026-03-05T21:52:22.759Z",
   "lastModified": "2026-03-05T21:52:22.759Z",
   "mestiereId": "9633d8e1-88a6-44f1-9e8c-50b3732b4ffa",
-  "abilitySortOption": "mp-asc"
+  "abilitySortOption": ""
 }

--- a/data/characters/biko.json
+++ b/data/characters/biko.json
@@ -355,7 +355,7 @@
   "lastModified": "2026-04-15T12:17:22.976Z",
   "mestiereId": "4eccfe5d-de19-4bc5-8c9c-374d793d67f0",
   "groupEquipmentBySource": false,
-  "equipmentSortOption": "keeping-asc",
+  "equipmentSortOption": "",
   "groupAbilitiesBySource": true,
   "abilitySortOption": "",
   "autoCalculations": {

--- a/data/characters/cheech.json
+++ b/data/characters/cheech.json
@@ -259,8 +259,8 @@
   "activeEffects": [],
   "groupAbilitiesBySource": true,
   "groupEquipmentBySource": false,
-  "abilitySortOption": "name-asc",
-  "equipmentSortOption": "name-asc",
+  "abilitySortOption": "",
+  "equipmentSortOption": "",
   "autoCalculations": {
     "load": true,
     "statesAndEffects": true

--- a/data/characters/natsu.json
+++ b/data/characters/natsu.json
@@ -16,7 +16,7 @@
   "personalityAndBackground": "Arrived too late to join the Asana Commune before it was destroyed. Squatting in the ruins. Big speech impediment.",
   "xp": 10,
   "mp": {
-    "current": 3,
+    "current": 5,
     "max": 5
   },
   "body": 3,
@@ -298,8 +298,8 @@
     "https://cdn.midjourney.com/a6773dd7-3da8-4349-9212-b021c7aa09f7/0_2.png"
   ],
   "userId": "dKLeSmonNhc6zNc2QYmUKFWIsFs1",
-  "updatedAt": "2026-04-20T14:53:59.079Z",
-  "lastModified": "2026-04-20T14:53:59.080Z",
+  "updatedAt": "2026-04-20T15:02:49.186Z",
+  "lastModified": "2026-04-20T15:02:49.186Z",
   "mestiereId": "937d52da-0ebf-4d74-b3ee-be395f2f5d0a",
   "age": 23,
   "heightFeet": 4,
@@ -334,11 +334,11 @@
     }
   },
   "biomeTags": [
+    "plains",
     "water",
-    "underground",
-    "cold"
+    "temperate"
   ],
-  "biomeId": "cb1dcc26-e6d7-4db7-a449-9affcffa67b8",
+  "biomeId": "c5adb6ab-3ae3-4521-8714-f7581d045e32",
   "groupAbilitiesBySource": false,
   "groupEquipmentBySource": false,
   "groupEquipmentByCustom": false,

--- a/data/characters/natsu.json
+++ b/data/characters/natsu.json
@@ -186,78 +186,93 @@
       "id": "43b5ef83-6a24-4912-93c2-29487b0b9f91",
       "quantity": 1,
       "isCarried": true,
-      "isWielding": false,
-      "collapsed": false
+      "isWielding": true,
+      "collapsed": true,
+      "columnIndex": 0,
+      "customGroupId": "11712a09-e1b1-4c70-b47e-26d8245a8855"
     },
     {
       "id": "2f54077d-56bd-46a6-9ad5-a7acdc7a90cf",
       "quantity": 1,
       "isCarried": true,
-      "isWielding": false,
-      "collapsed": false
+      "isWielding": true,
+      "collapsed": true,
+      "columnIndex": 1,
+      "customGroupId": null
     },
     {
       "id": "e43614f2-91e1-495f-9d4f-7cdc4d87d3be",
       "quantity": 1,
       "isCarried": true,
-      "isWielding": false,
-      "collapsed": false
+      "isWielding": true,
+      "collapsed": true,
+      "columnIndex": 2,
+      "customGroupId": null
     }
   ],
   "abilities": [
     {
-      "id": "90315f32-f485-498d-8d83-f8dad2f32882",
+      "id": "b647caa0-11d8-4a34-b384-fde758eaf90e",
       "collapsed": true,
       "showImprovements": false,
-      "showSuccesses": false
-    },
-    {
-      "id": "eca2de98-4fb0-4254-bb03-af81f8a604ff",
-      "collapsed": true,
-      "showImprovements": false,
-      "showSuccesses": false
+      "showSuccesses": false,
+      "customGroupId": "05f73331-5708-4305-a84c-bc4e8b4eb491"
     },
     {
       "id": "9a047b93-d2c2-4de0-ae7e-0fa06b459a29",
       "collapsed": true,
       "showImprovements": false,
-      "showSuccesses": false
-    },
-    {
-      "id": "b647caa0-11d8-4a34-b384-fde758eaf90e",
-      "collapsed": true,
-      "showImprovements": false,
-      "showSuccesses": false
-    },
-    {
-      "id": "fdc9ab63-b9b4-41de-a869-d2274cea32ec",
-      "collapsed": true,
-      "showImprovements": false,
-      "showSuccesses": false
+      "showSuccesses": false,
+      "customGroupId": "05f73331-5708-4305-a84c-bc4e8b4eb491"
     },
     {
       "id": "e2cd82f4-30db-4c3e-aa76-20170b5e7694",
       "collapsed": true,
       "showImprovements": false,
-      "showSuccesses": false
+      "showSuccesses": false,
+      "customGroupId": null
+    },
+    {
+      "id": "90315f32-f485-498d-8d83-f8dad2f32882",
+      "collapsed": true,
+      "showImprovements": false,
+      "showSuccesses": false,
+      "customGroupId": null
     },
     {
       "id": "738255ac-87f1-45a5-91ff-c2144b92b5e3",
       "collapsed": true,
       "showImprovements": false,
-      "showSuccesses": false
+      "showSuccesses": false,
+      "customGroupId": null
     },
     {
       "id": "1325605b-d523-4ec2-b2a7-57a04dc55d91",
       "collapsed": true,
       "showImprovements": false,
-      "showSuccesses": false
+      "showSuccesses": false,
+      "customGroupId": null
     },
     {
       "id": "754a7883-71a7-414f-bda4-504a147e68cc",
       "collapsed": true,
       "showImprovements": false,
-      "showSuccesses": false
+      "showSuccesses": false,
+      "customGroupId": null
+    },
+    {
+      "id": "eca2de98-4fb0-4254-bb03-af81f8a604ff",
+      "collapsed": true,
+      "showImprovements": false,
+      "showSuccesses": false,
+      "customGroupId": null
+    },
+    {
+      "id": "fdc9ab63-b9b4-41de-a869-d2274cea32ec",
+      "collapsed": true,
+      "showImprovements": false,
+      "showSuccesses": false,
+      "customGroupId": null
     }
   ],
   "activeEffects": [
@@ -283,8 +298,8 @@
     "https://cdn.midjourney.com/a6773dd7-3da8-4349-9212-b021c7aa09f7/0_2.png"
   ],
   "userId": "dKLeSmonNhc6zNc2QYmUKFWIsFs1",
-  "updatedAt": "2026-04-18T22:16:21.902Z",
-  "lastModified": "2026-04-18T22:16:21.902Z",
+  "updatedAt": "2026-04-20T13:35:31.957Z",
+  "lastModified": "2026-04-20T13:35:31.957Z",
   "mestiereId": "937d52da-0ebf-4d74-b3ee-be395f2f5d0a",
   "age": 23,
   "heightFeet": 4,
@@ -324,5 +339,23 @@
     "cold"
   ],
   "biomeId": "cb1dcc26-e6d7-4db7-a449-9affcffa67b8",
-  "groupAbilitiesBySource": true
+  "groupAbilitiesBySource": false,
+  "groupEquipmentBySource": false,
+  "groupEquipmentByCustom": false,
+  "equipmentCustomGroups": [
+    {
+      "id": "11712a09-e1b1-4c70-b47e-26d8245a8855",
+      "name": "Cool Bits"
+    }
+  ],
+  "groupAbilitiesByManaColor": false,
+  "groupAbilitiesByCustom": false,
+  "abilityCustomGroups": [
+    {
+      "id": "05f73331-5708-4305-a84c-bc4e8b4eb491",
+      "name": "Cool Spells"
+    }
+  ],
+  "abilitySortOption": "xp-asc",
+  "equipmentSortOption": "name-asc"
 }

--- a/data/characters/natsu.json
+++ b/data/characters/natsu.json
@@ -298,8 +298,8 @@
     "https://cdn.midjourney.com/a6773dd7-3da8-4349-9212-b021c7aa09f7/0_2.png"
   ],
   "userId": "dKLeSmonNhc6zNc2QYmUKFWIsFs1",
-  "updatedAt": "2026-04-20T13:35:31.957Z",
-  "lastModified": "2026-04-20T13:35:31.957Z",
+  "updatedAt": "2026-04-20T14:53:59.079Z",
+  "lastModified": "2026-04-20T14:53:59.080Z",
   "mestiereId": "937d52da-0ebf-4d74-b3ee-be395f2f5d0a",
   "age": 23,
   "heightFeet": 4,

--- a/data/characters/natsu.json
+++ b/data/characters/natsu.json
@@ -181,7 +181,29 @@
     "afraid": false,
     "troubled": false
   },
-  "equipment": [],
+  "equipment": [
+    {
+      "id": "43b5ef83-6a24-4912-93c2-29487b0b9f91",
+      "quantity": 1,
+      "isCarried": true,
+      "isWielding": false,
+      "collapsed": false
+    },
+    {
+      "id": "2f54077d-56bd-46a6-9ad5-a7acdc7a90cf",
+      "quantity": 1,
+      "isCarried": true,
+      "isWielding": false,
+      "collapsed": false
+    },
+    {
+      "id": "e43614f2-91e1-495f-9d4f-7cdc4d87d3be",
+      "quantity": 1,
+      "isCarried": true,
+      "isWielding": false,
+      "collapsed": false
+    }
+  ],
   "abilities": [
     {
       "id": "90315f32-f485-498d-8d83-f8dad2f32882",
@@ -261,8 +283,8 @@
     "https://cdn.midjourney.com/a6773dd7-3da8-4349-9212-b021c7aa09f7/0_2.png"
   ],
   "userId": "dKLeSmonNhc6zNc2QYmUKFWIsFs1",
-  "updatedAt": "2026-04-15T12:35:07.382Z",
-  "lastModified": "2026-04-15T12:35:07.382Z",
+  "updatedAt": "2026-04-18T22:16:21.902Z",
+  "lastModified": "2026-04-18T22:16:21.902Z",
   "mestiereId": "937d52da-0ebf-4d74-b3ee-be395f2f5d0a",
   "age": 23,
   "heightFeet": 4,

--- a/data/concepts/dragonborn.json
+++ b/data/concepts/dragonborn.json
@@ -2,7 +2,7 @@
   "id": "ba7af7ad-54d2-4b45-86ad-71781d4cdb33",
   "conceptType": "ANCESTRY",
   "name": "Dragonborn",
-  "description": "<p>Born of some ancient, improbable union lost to living knowledge, the Dragonborn bear the strength of dragons within the frame of a humanoid form. Some cultivate these unusual gifts and wield them with pride. Others see them as a burden to be overcome. All stand out in a crowd - typically tall and imposing, with scales and horns of many colors.</p><p><strong><em>Height</em></strong><em>: 5-7' </em>| <strong><em>Weight</em></strong><em>: 150-400 lbs </em>| <strong><em>Average Lifespan</em></strong><em>: 90 years </em>| <strong><em>Speed</em></strong><em>: 30</em></p>",
+  "description": "<p>Born of some ancient, improbable union lost to living knowledge, the Dragonborn bear the strength of dragons within the frame of a humanoid form. Some cultivate these unusual gifts and wield them with pride. Others see them as a burden to be overcome. All stand out in a crowd - typically tall and imposing, with scales and horns of many colors.</p>",
   "isDeleted": false,
   "artUrls": [
     "https://cdn.midjourney.com/d36b8637-3c46-48f3-9a7b-b98750195974/0_2.png"
@@ -19,6 +19,13 @@
   "vittles": "",
   "pointsOfInterest": "",
   "floraFauna": "",
-  "lastModified": "2026-02-25T13:26:19.115Z",
-  "expansionLogoUrl": "https://cdn.midjourney.com/a74946da-ccb3-4540-89e9-751411b6bb7c/0_1.png"
+  "lastModified": "2026-04-18T00:24:15.983Z",
+  "expansionLogoUrl": "https://cdn.midjourney.com/a74946da-ccb3-4540-89e9-751411b6bb7c/0_1.png",
+  "detailBackgroundImage": "https://cdn.midjourney.com/5e0fa395-5759-4772-9fdd-29be4ce0072f/0_0.png",
+  "heightMin": 5,
+  "heightMax": 7,
+  "weightMin": 150,
+  "weightMax": 400,
+  "lifespan": "90 years",
+  "speed": 30
 }

--- a/data/concepts/drow.json
+++ b/data/concepts/drow.json
@@ -2,7 +2,7 @@
   "id": "2e46823f-bec7-4d70-b323-dbc8b71c7739",
   "conceptType": "ANCESTRY",
   "name": "Drow",
-  "description": "<p>Distant kin to surface Elves, the Drow have spent uncountable generations dwelling in the lightless places beneath the world. Their eyes are wide and luminous, built to catch even the faintest glimmer in absolute dark. Their skin runs from deep grey to dark violet, and their hair is almost universally white. Whatever estrangement first drove them underground is ancient enough to be legend now — what remains is simply a people shaped wholly by the deep.</p><p><strong><em>Height</em></strong><em>: 5-6' </em>| <strong><em>Weight</em></strong><em>: 75-225 lbs </em>| <strong><em>Average Lifespan</em></strong><em>: undying </em>| <strong><em>Speed</em></strong><em>: 30</em></p>",
+  "description": "<p>Distant kin to surface Elves, the Drow have spent uncountable generations dwelling in the lightless places beneath the world. Their eyes are wide and luminous, built to catch even the faintest glimmer in absolute dark. Their skin runs from deep grey to dark violet, and their hair is almost universally white. Whatever estrangement first drove them underground is ancient enough to be legend now — what remains is simply a people shaped wholly by the deep.</p>",
   "isDeleted": false,
   "artUrls": [
     "https://cdn.midjourney.com/0333b110-ab2f-4965-ae32-3c67dba0a0f3/0_2.png"
@@ -19,5 +19,12 @@
   "vittles": "",
   "pointsOfInterest": "",
   "floraFauna": "",
-  "lastModified": "2026-02-26T02:03:25.514Z"
+  "lastModified": "2026-04-18T00:28:07.874Z",
+  "detailBackgroundImage": "https://cdn.midjourney.com/f8c33089-e573-46c2-a31e-e3cb6fa84f32/0_2.png",
+  "heightMin": 5,
+  "heightMax": 6,
+  "weightMin": 75,
+  "weightMax": 225,
+  "lifespan": "undying",
+  "speed": 30
 }

--- a/data/concepts/dwarf.json
+++ b/data/concepts/dwarf.json
@@ -2,7 +2,7 @@
   "id": "adc655c1-1d9c-433f-a0eb-41f93cf3ee07",
   "conceptType": "ANCESTRY",
   "name": "Dwarf",
-  "description": "<p>Stout in stature and typically broad in bearing, some say that the Dwarves emerged fully-formed from within the mountains themselves. More likely they are descended from folk who fell in love with the hidden places within the Earth. Many long generations of subterranean exploration and toil have made them sturdy and hardy.</p><p><strong><em>Height</em></strong><em>: 4-5' </em>| <strong><em>Weight</em></strong><em>: 120-375 lbs </em>| <strong><em>Average Lifespan</em></strong><em>: 350 years </em>| <strong><em>Speed</em></strong><em>: 25</em></p>",
+  "description": "<p>Stout in stature and typically broad in bearing, some say that the Dwarves emerged fully-formed from within the mountains themselves. More likely they are descended from folk who fell in love with the hidden places within the Earth. Many long generations of subterranean exploration and toil have made them sturdy and hardy.</p>",
   "isDeleted": false,
   "artUrls": [
     "https://cdn.midjourney.com/b75951b3-d21b-4e00-b7c8-c81fc16c043e/0_2.png"
@@ -19,5 +19,12 @@
   "vittles": "",
   "pointsOfInterest": "",
   "floraFauna": "",
-  "lastModified": "2026-02-25T19:08:36.176Z"
+  "lastModified": "2026-04-18T02:27:55.083Z",
+  "detailBackgroundImage": "https://cdn.midjourney.com/fad3ec31-91c1-4b4c-8172-725a2f07e670/0_3.png",
+  "heightMin": 4,
+  "heightMax": 5,
+  "weightMin": 120,
+  "weightMax": 375,
+  "lifespan": "350 years",
+  "speed": 25
 }

--- a/data/concepts/elf.json
+++ b/data/concepts/elf.json
@@ -2,7 +2,7 @@
   "id": "f5cda222-6c69-4ae9-bc0d-761729cd8e2e",
   "conceptType": "ANCESTRY",
   "name": "Elf",
-  "description": "<p>Elves move through the world with an uncommon physical lightness, as though gravity has a slightly looser hold on them than on most. They tend toward keen senses and an unmistakable affinity for open water and the night sky. Their draw toward fine craft and jeweled work is well-attested. None of this makes them better than anyone else — only particular.</p><p><strong><em>Height</em></strong><em>: 5-6' </em>| <strong><em>Weight</em></strong><em>: 75-225 lbs </em>| <strong><em>Average Lifespan</em></strong><em>: undying </em>| <strong><em>Speed</em></strong><em>: 30</em></p>",
+  "description": "<p>Elves move through the world with an uncommon physical lightness, as though gravity has a slightly looser hold on them than on most. They tend toward keen senses and an unmistakable affinity for open water and the night sky. Their draw toward fine craft and jeweled work is well-attested. None of this makes them better than anyone else — only particular.</p>",
   "isDeleted": false,
   "artUrls": [
     "https://cdn.midjourney.com/831b273e-9002-4112-ba61-082d83341ba6/0_3.png"
@@ -19,5 +19,12 @@
   "vittles": "",
   "pointsOfInterest": "",
   "floraFauna": "",
-  "lastModified": "2026-03-19T01:47:48.040Z"
+  "lastModified": "2026-04-18T02:27:45.739Z",
+  "detailBackgroundImage": "",
+  "heightMin": 5,
+  "heightMax": 6,
+  "weightMin": 75,
+  "weightMax": 225,
+  "lifespan": "undying",
+  "speed": 30
 }

--- a/data/concepts/falena.json
+++ b/data/concepts/falena.json
@@ -2,7 +2,7 @@
   "id": "d7578278-c801-410b-b194-12b555042f29",
   "conceptType": "ANCESTRY",
   "name": "Falena",
-  "description": "<p>The Falena bear the features of insects — foremost among them the moth, though the family is broad. Fine antennae rise from their brows, lending them a subtle sensitivity to the emotions and intentions of those nearby. Most have wings, delicate and patterned like stained glass; others have dextrous legs and feet that can cling to any surface.</p><p><strong><em>Height</em></strong><em>: 3-6' </em>| <strong><em>Weight</em></strong><em>: 50-250 lbs </em>| <strong><em>Average Lifespan</em></strong><em>: 50 years </em>| <strong><em>Speed</em></strong><em>: 30</em></p>",
+  "description": "<p>The Falena bear the features of insects — foremost among them the moth, though the family is broad. Fine antennae rise from their brows, lending them a subtle sensitivity to the emotions and intentions of those nearby. Most have wings, delicate and patterned like stained glass; others have dextrous legs and feet that can cling to any surface.</p>",
   "isDeleted": false,
   "artUrls": [
     "https://cdn.midjourney.com/a4e20f92-a7de-47e6-8445-f499a6d406e5/0_2.png"
@@ -19,5 +19,11 @@
   "vittles": "",
   "pointsOfInterest": "",
   "floraFauna": "",
-  "lastModified": "2026-02-25T14:13:05.016Z"
+  "lastModified": "2026-02-25T14:13:05.016Z",
+  "heightMin": 3,
+  "heightMax": 6,
+  "weightMin": 50,
+  "weightMax": 250,
+  "lifespan": "50 years",
+  "speed": 30
 }

--- a/data/concepts/fey.json
+++ b/data/concepts/fey.json
@@ -2,7 +2,7 @@
   "id": "f00fe427-1bb5-472c-8abb-2a394730a40a",
   "conceptType": "ANCESTRY",
   "name": "Fey",
-  "description": "<p>Born where the seam between the mortal and fae worlds ran thin enough to bleed through, the Fey carry two natures at once. What the world sees is their glamour: a humanoid form, chosen and maintained by instinct. Beneath it lies their true form — stranger, wilder, less easy to name.</p><p><strong><em>Height</em></strong><em>: 5-7' </em>| <strong><em>Weight</em></strong><em>: 75-500 lbs </em>| <strong><em>Average Lifespan</em></strong><em>: undying </em>| <strong><em>Speed</em></strong><em>: 30</em></p>",
+  "description": "<p>Born where the seam between the mortal and fae worlds ran thin enough to bleed through, the Fey carry two natures at once. What the world sees is their glamour: a humanoid form, chosen and maintained by instinct. Beneath it lies their true form — stranger, wilder, less easy to name.</p>",
   "isDeleted": false,
   "artUrls": [
     "https://cdn.midjourney.com/56acc187-316c-4d6a-aba8-f64ad6b5c126/0_2.png"
@@ -19,5 +19,11 @@
   "vittles": "",
   "pointsOfInterest": "",
   "floraFauna": "",
-  "lastModified": "2026-02-25T19:26:35.196Z"
+  "lastModified": "2026-02-25T19:26:35.196Z",
+  "heightMin": 5,
+  "heightMax": 7,
+  "weightMin": 75,
+  "weightMax": 500,
+  "lifespan": "undying",
+  "speed": 30
 }

--- a/data/concepts/furu.json
+++ b/data/concepts/furu.json
@@ -2,7 +2,7 @@
   "id": "d5e3228b-1d04-4503-8ec6-3210d420c082",
   "conceptType": "ANCESTRY",
   "name": "Furu",
-  "description": "<p>The Furu emerged from the deep north, where winters outlast hope. Owl-like in feature — large, still eyes set wide in a broad face, and a quality of total silence when they choose stillness — they are something stranger than simple avian humanoids. What sets them apart more than any physical trait is their memory: complete, unhurried, and very nearly perfect. They forget nothing, which is not always the gift it sounds.</p><p><strong><em>Height</em></strong><em>: 6-7' </em>| <strong><em>Weight</em></strong><em>: 100-325 lbs </em>| <strong><em>Average Lifespan</em></strong><em>: 120 years </em>| <strong><em>Speed</em></strong><em>: 30</em></p>",
+  "description": "<p>The Furu emerged from the deep north, where winters outlast hope. Owl-like in feature — large, still eyes set wide in a broad face, and a quality of total silence when they choose stillness — they are something stranger than simple avian humanoids. What sets them apart more than any physical trait is their memory: complete, unhurried, and very nearly perfect. They forget nothing, which is not always the gift it sounds.</p>",
   "isDeleted": false,
   "artUrls": [
     "https://cdn.midjourney.com/4d48d295-4aa2-46bb-9db0-448f8c241347/0_1.png"
@@ -19,5 +19,11 @@
   "vittles": "",
   "pointsOfInterest": "",
   "floraFauna": "",
-  "lastModified": "2025-12-13T19:15:03.738Z"
+  "lastModified": "2025-12-13T19:15:03.738Z",
+  "heightMin": 6,
+  "heightMax": 7,
+  "weightMin": 100,
+  "weightMax": 325,
+  "lifespan": "120 years",
+  "speed": 30
 }

--- a/data/concepts/gearborn.json
+++ b/data/concepts/gearborn.json
@@ -2,7 +2,7 @@
   "id": "cfd7bf18-3a9a-4b4e-a9a9-c7069dd822c3",
   "conceptType": "ANCESTRY",
   "name": "Gearborn",
-  "description": "<p>Fashioned from metal, stone, and purposes now obscure, the Gearborn wake into a world that remembers nothing of those who made them. The civilization responsible has passed entirely from living history — no ruins carry useful answers, no text survives in legible form. Each Gearborn is, in a sense, a question without an origin. They carry this in the particular stillness behind their eyes.</p><p><strong><em>Height</em></strong><em>: 3-8' </em>| <strong><em>Weight</em></strong><em>: 150-1000 lbs </em>| <strong><em>Average Lifespan</em></strong><em>: undying </em>| <strong><em>Speed</em></strong><em>: 30</em></p>",
+  "description": "<p>Fashioned from metal, stone, and purposes now obscure, the Gearborn wake into a world that remembers nothing of those who made them. The civilization responsible has passed entirely from living history — no ruins carry useful answers, no text survives in legible form. Each Gearborn is, in a sense, a question without an origin. They carry this in the particular stillness behind their eyes.</p>",
   "isDeleted": false,
   "artUrls": [
     "https://cdn.midjourney.com/6f95a939-4378-49cc-ac4c-8f99d962a4c1/0_2.png"
@@ -19,5 +19,11 @@
   "vittles": "",
   "pointsOfInterest": "",
   "floraFauna": "",
-  "lastModified": "2026-02-25T19:26:50.208Z"
+  "lastModified": "2026-02-25T19:26:50.208Z",
+  "heightMin": 3,
+  "heightMax": 8,
+  "weightMin": 150,
+  "weightMax": 1000,
+  "lifespan": "undying",
+  "speed": 30
 }

--- a/data/concepts/giantkin.json
+++ b/data/concepts/giantkin.json
@@ -2,7 +2,7 @@
   "id": "134acec3-0e13-42e1-9d75-7999340d458c",
   "conceptType": "ANCESTRY",
   "name": "Giantkin",
-  "description": "<p>In the oldest accounts, the Giants did not merely live upon the land — they shaped it, hollowed it, and some say merged with it at the last, becoming the mountains themselves. The Giantkin are all that remains of them in the world of the living: tall, broad, and built to endure in ways that make ordinary hardship feel like a light breeze. Their past is beyond recovery. The peaks persist, but they do not speak.</p><p><strong><em>Height</em></strong><em>: 7-9' </em>| <strong><em>Weight</em></strong><em>: 275-700 lbs </em>| <strong><em>Average Lifespan</em></strong><em>: 200 years </em>| <strong><em>Speed</em></strong><em>: 30</em></p>",
+  "description": "<p>In the oldest accounts, the Giants did not merely live upon the land — they shaped it, hollowed it, and some say merged with it at the last, becoming the mountains themselves. The Giantkin are all that remains of them in the world of the living: tall, broad, and built to endure in ways that make ordinary hardship feel like a light breeze. Their past is beyond recovery. The peaks persist, but they do not speak.</p>",
   "isDeleted": false,
   "artUrls": [
     "https://cdn.midjourney.com/20207a5c-0193-4b5a-84b7-519887005460/0_2.png"
@@ -19,5 +19,11 @@
   "vittles": "",
   "pointsOfInterest": "",
   "floraFauna": "",
-  "lastModified": "2025-11-20T15:44:47.233Z"
+  "lastModified": "2025-11-20T15:44:47.233Z",
+  "heightMin": 7,
+  "heightMax": 9,
+  "weightMin": 275,
+  "weightMax": 700,
+  "lifespan": "200 years",
+  "speed": 30
 }

--- a/data/concepts/gnome.json
+++ b/data/concepts/gnome.json
@@ -2,7 +2,7 @@
   "id": "fffc6b74-d66f-4270-a8b4-e045433ae176",
   "conceptType": "ANCESTRY",
   "name": "Gnome",
-  "description": "<p>Small in stature and enormous in curiosity, Gnomes are drawn to complexity the way other folk are drawn to warmth. A mechanism unexamined, a puzzle unturned, a question unasked — these feel to a Gnome like unfinished business. They are not especially well-suited to sitting still.</p><p><strong><em>Height</em></strong><em>: 2-3' </em>| <strong><em>Weight</em></strong><em>: 20-75 lbs </em>| <strong><em>Average Lifespan</em></strong><em>: 200 years </em>| <strong><em>Speed</em></strong><em>: 20</em></p>",
+  "description": "<p>Small in stature and enormous in curiosity, Gnomes are drawn to complexity the way other folk are drawn to warmth. A mechanism unexamined, a puzzle unturned, a question unasked — these feel to a Gnome like unfinished business. They are not especially well-suited to sitting still.</p>",
   "isDeleted": false,
   "artUrls": [
     "https://cdn.midjourney.com/353a461b-7107-4426-a4a8-c2e536ce42da/0_2.png"
@@ -19,5 +19,11 @@
   "vittles": "",
   "pointsOfInterest": "",
   "floraFauna": "",
-  "lastModified": "2026-02-03T14:07:43.177Z"
+  "lastModified": "2026-02-03T14:07:43.177Z",
+  "heightMin": 2,
+  "heightMax": 3,
+  "weightMin": 20,
+  "weightMax": 75,
+  "lifespan": "200 years",
+  "speed": 20
 }

--- a/data/concepts/goblin.json
+++ b/data/concepts/goblin.json
@@ -2,7 +2,7 @@
   "id": "6ff91bc4-122f-4e95-bb08-b577f1a94bb6",
   "conceptType": "ANCESTRY",
   "name": "Goblin",
-  "description": "<p>Quick, sharp-featured, and possessed of more energy than their frame suggests it can contain, Goblins are a people of striking variety — their skin comes in every shade the world has to offer. Whatever darkness may have touched their ancient origins is long worn away by the ordinary work of living. What persists is spryness, tenacity and a willingness to throw caution to the wind.</p><p><strong><em>Height</em></strong><em>: 3-4' </em>| <strong><em>Weight</em></strong><em>: 30-120 lbs </em>| <strong><em>Average Lifespan</em></strong><em>: 60 years </em>| <strong><em>Speed</em></strong><em>: 30</em></p>",
+  "description": "<p>Quick, sharp-featured, and possessed of more energy than their frame suggests it can contain, Goblins are a people of striking variety — their skin comes in every shade the world has to offer. Whatever darkness may have touched their ancient origins is long worn away by the ordinary work of living. What persists is spryness, tenacity and a willingness to throw caution to the wind.</p>",
   "isDeleted": false,
   "artUrls": [
     "https://cdn.midjourney.com/33cf6394-1488-4dbf-b76d-e9205a9410cd/0_2.png"
@@ -19,5 +19,11 @@
   "vittles": "",
   "pointsOfInterest": "",
   "floraFauna": "",
-  "lastModified": "2026-02-25T14:17:40.656Z"
+  "lastModified": "2026-02-25T14:17:40.656Z",
+  "heightMin": 3,
+  "heightMax": 4,
+  "weightMin": 30,
+  "weightMax": 120,
+  "lifespan": "60 years",
+  "speed": 30
 }

--- a/data/concepts/grung.json
+++ b/data/concepts/grung.json
@@ -2,7 +2,7 @@
   "id": "9250fcc5-9bc9-4724-815d-4411e79d403c",
   "conceptType": "ANCESTRY",
   "name": "Grung",
-  "description": "<p>Brightly-colored, smooth-skinned, large-eyed -  the Grung are typically wary. Their survival instincts tend to run close to the surface and their poisonous skin keeps others at a distance. They do not often stray far from water without some provision of it to keep themselves from drying out, and their affinity for the natural world allows them to avoid danger in a pinch.</p><p><strong><em>Height</em></strong><em>: 3-4' </em>| <strong><em>Weight</em></strong><em>: 40-150 lbs </em>| <strong><em>Average Lifespan</em></strong><em>: 50 years </em>| <strong><em>Speed</em></strong><em>: 25</em></p>",
+  "description": "<p>Brightly-colored, smooth-skinned, large-eyed -  the Grung are typically wary. Their survival instincts tend to run close to the surface and their poisonous skin keeps others at a distance. They do not often stray far from water without some provision of it to keep themselves from drying out, and their affinity for the natural world allows them to avoid danger in a pinch.</p>",
   "isDeleted": false,
   "artUrls": [
     "https://cdn.midjourney.com/6a52d112-8461-45a7-bf01-3c17367af7c8/0_1.png"
@@ -19,5 +19,11 @@
   "vittles": "",
   "pointsOfInterest": "",
   "floraFauna": "",
-  "lastModified": "2026-02-25T14:24:31.812Z"
+  "lastModified": "2026-02-25T14:24:31.812Z",
+  "heightMin": 3,
+  "heightMax": 4,
+  "weightMin": 40,
+  "weightMax": 150,
+  "lifespan": "50 years",
+  "speed": 25
 }

--- a/data/concepts/halfling.json
+++ b/data/concepts/halfling.json
@@ -2,7 +2,7 @@
   "id": "77e4f81a-728f-49a7-a013-4d6f666353e2",
   "conceptType": "ANCESTRY",
   "name": "Halfling",
-  "description": "<p>Of modest height and build, Halflings are lighter on their feet than almost anyone has a right to be. Their senses are sharp, their reflexes quicker than their size implies, and they have a long-established reputation for appearing in exactly the place you weren't watching.</p><p><strong><em>Height</em></strong><em>: 3-4' </em>| <strong><em>Weight</em></strong><em>: 50-180 lbs </em>| <strong><em>Average Lifespan</em></strong><em>: 125 years </em>| <strong><em>Speed</em></strong><em>: 25</em></p>",
+  "description": "<p>Of modest height and build, Halflings are lighter on their feet than almost anyone has a right to be. Their senses are sharp, their reflexes quicker than their size implies, and they have a long-established reputation for appearing in exactly the place you weren't watching.</p>",
   "isDeleted": false,
   "artUrls": [
     "https://cdn.midjourney.com/033e30ef-e853-44db-971b-ba105fd8a590/0_3.png"
@@ -19,5 +19,11 @@
   "vittles": "",
   "pointsOfInterest": "",
   "floraFauna": "",
-  "lastModified": "2026-02-25T14:25:14.291Z"
+  "lastModified": "2026-02-25T14:25:14.291Z",
+  "heightMin": 3,
+  "heightMax": 4,
+  "weightMin": 50,
+  "weightMax": 180,
+  "lifespan": "125 years",
+  "speed": 25
 }

--- a/data/concepts/human.json
+++ b/data/concepts/human.json
@@ -2,7 +2,7 @@
   "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
   "conceptType": "ANCESTRY",
   "name": "Human",
-  "description": "<p>Humans are not the strongest, nor the quickest, nor the longest-lived. What they are is adaptable — constitutionally, stubbornly so. Where other peoples are often shaped by a deep affinity for one way of being, Humans are shaped by the capacity to adapt. It is a less dramatic gift than most, and rarer than it looks.</p><p><strong><em>Height</em></strong><em>: 5-6' </em>| <strong><em>Weight</em></strong><em>: 100-350 lbs </em>| <strong><em>Average Lifespan</em></strong><em>: 80 years </em>| <strong><em>Speed</em></strong><em>: 30</em></p>",
+  "description": "<p>Humans are not the strongest, nor the quickest, nor the longest-lived. What they are is adaptable — constitutionally, stubbornly so. Where other peoples are often shaped by a deep affinity for one way of being, Humans are shaped by the capacity to adapt. It is a less dramatic gift than most, and rarer than it looks.</p>",
   "isDeleted": false,
   "artUrls": [
     "https://cdn.midjourney.com/6996ccd1-d214-4f22-ac97-21f819a25e36/0_1.png"
@@ -19,5 +19,11 @@
   "vittles": "",
   "pointsOfInterest": "",
   "floraFauna": "",
-  "lastModified": "2026-02-26T16:10:54.862Z"
+  "lastModified": "2026-02-26T16:10:54.862Z",
+  "heightMin": 5,
+  "heightMax": 6,
+  "weightMin": 100,
+  "weightMax": 350,
+  "lifespan": "80 years",
+  "speed": 30
 }

--- a/data/concepts/musteval.json
+++ b/data/concepts/musteval.json
@@ -2,7 +2,7 @@
   "id": "b6f7cc3e-f689-4cd9-a8ed-73bf5e7f0fef",
   "conceptType": "ANCESTRY",
   "name": "Musteval",
-  "description": "<p>Mouselike in feature and modest in stature, the Musteval are easy to underestimate. They carry within them a quiet attunement to divine presence, like an ear for music. Sacred beings find the Musteval unusually easy to hear, and are in turn unusually willing to listen.</p><p><strong><em>Height</em></strong><em>: 3-4' </em>| <strong><em>Weight</em></strong><em>: 30-100 lbs </em>| <strong><em>Average Lifespan</em></strong><em>: 100 years </em>| <strong><em>Speed</em></strong><em>: 25</em></p>",
+  "description": "<p>Mouselike in feature and modest in stature, the Musteval are easy to underestimate. They carry within them a quiet attunement to divine presence, like an ear for music. Sacred beings find the Musteval unusually easy to hear, and are in turn unusually willing to listen.</p>",
   "isDeleted": false,
   "artUrls": [
     "https://cdn.midjourney.com/7a1fcf86-49b5-4371-b51c-de1799128ab6/0_3.jpeg"
@@ -19,5 +19,11 @@
   "vittles": "",
   "pointsOfInterest": "",
   "floraFauna": "",
-  "lastModified": "2026-02-26T16:26:03.589Z"
+  "lastModified": "2026-02-26T16:26:03.589Z",
+  "heightMin": 3,
+  "heightMax": 4,
+  "weightMin": 30,
+  "weightMax": 100,
+  "lifespan": "100 years",
+  "speed": 25
 }

--- a/data/concepts/orc.json
+++ b/data/concepts/orc.json
@@ -2,7 +2,7 @@
   "id": "eed942f5-8cc4-446a-8806-b83186098274",
   "conceptType": "ANCESTRY",
   "name": "Orc",
-  "description": "<p>Orcs are large, broad, and built for endurance — their skin ranging from gray to green, some bearing tusks, others not. Old stories cast them as creatures of destruction and ruin, but an Orc will tell you that those stories were not told by them. What persists in the Orcish body is simply strength, and an appetite for using it.</p><p><strong><em>Height</em></strong><em>: 4-6' </em>| <strong><em>Weight</em></strong><em>: 100-375 lbs </em>| <strong><em>Average Lifespan</em></strong><em>: 60 years </em>| <strong><em>Speed</em></strong><em>: 30</em></p>",
+  "description": "<p>Orcs are large, broad, and built for endurance — their skin ranging from gray to green, some bearing tusks, others not. Old stories cast them as creatures of destruction and ruin, but an Orc will tell you that those stories were not told by them. What persists in the Orcish body is simply strength, and an appetite for using it.</p>",
   "isDeleted": false,
   "artUrls": [
     "https://cdn.midjourney.com/8d595be7-bd0e-44c1-ba84-8a49dc8b357a/0_2.png"
@@ -19,5 +19,11 @@
   "vittles": "",
   "pointsOfInterest": "",
   "floraFauna": "",
-  "lastModified": "2026-02-26T18:58:34.289Z"
+  "lastModified": "2026-02-26T18:58:34.289Z",
+  "heightMin": 4,
+  "heightMax": 6,
+  "weightMin": 100,
+  "weightMax": 375,
+  "lifespan": "60 years",
+  "speed": 30
 }

--- a/data/concepts/ropekin.json
+++ b/data/concepts/ropekin.json
@@ -2,7 +2,7 @@
   "id": "15bb5476-5cca-48ee-a6a0-95b0ea6cc803",
   "conceptType": "ANCESTRY",
   "name": "Ropekin",
-  "description": "<p>The Ropekin are, somehow, made of rope. Braided, knotted, coiled where a torso ought to be — they are humanoid in every functional respect and entirely inexplicable in material. Legend has it that a sailor fell in love with their ship that they attempted to bring it to life, but only succeeded in imbuing the ship's rigging with vitality. The Ropekin themselves are largely unbothered by the mystery.</p><p><strong><em>Height</em></strong><em>: 4-7' </em>| <strong><em>Weight</em></strong><em>: 50-175 lbs </em>| <strong><em>Average Lifespan</em></strong><em>: undying </em>| <strong><em>Speed</em></strong><em>: 30</em></p>",
+  "description": "<p>The Ropekin are, somehow, made of rope. Braided, knotted, coiled where a torso ought to be — they are humanoid in every functional respect and entirely inexplicable in material. Legend has it that a sailor fell in love with their ship that they attempted to bring it to life, but only succeeded in imbuing the ship's rigging with vitality. The Ropekin themselves are largely unbothered by the mystery.</p>",
   "isDeleted": false,
   "artUrls": [
     "https://cdn.midjourney.com/1f42e7e8-da85-44ac-8046-f92d3e42e178/0_0.png"
@@ -19,5 +19,11 @@
   "vittles": "",
   "pointsOfInterest": "",
   "floraFauna": "",
-  "lastModified": "2026-02-25T19:30:44.290Z"
+  "lastModified": "2026-02-25T19:30:44.290Z",
+  "heightMin": 4,
+  "heightMax": 7,
+  "weightMin": 50,
+  "weightMax": 175,
+  "lifespan": "undying",
+  "speed": 30
 }

--- a/data/concepts/rospogenti_ancestry.json
+++ b/data/concepts/rospogenti_ancestry.json
@@ -2,7 +2,7 @@
   "id": "f9e8d7c6-b5a4-9382-7165-0f9e8d7c6b5a",
   "conceptType": "ANCESTRY",
   "name": "Rospogenti",
-  "description": "<p>Wide-set and solidly built, the Rospogenti share the temperament of toads: unhurried, practical, and difficult to ruffle. Their hides are exceptionally tough — not armor by design, but armor by nature. They carry themselves with the calm ease of beings who concluded long ago that most urgency is optional. They are not slow. They are deliberate, and they will be the first to tell you the difference.</p><p><strong><em>Height</em></strong><em>: 4-5' </em>| <strong><em>Weight</em></strong><em>: 125-400 lbs </em>| <strong><em>Average Lifespan</em></strong><em>: 75 years </em>| <strong><em>Speed</em></strong><em>: 30</em></p>",
+  "description": "<p>Wide-set and solidly built, the Rospogenti share the temperament of toads: unhurried, practical, and difficult to ruffle. Their hides are exceptionally tough — not armor by design, but armor by nature. They carry themselves with the calm ease of beings who concluded long ago that most urgency is optional. They are not slow. They are deliberate, and they will be the first to tell you the difference.</p>",
   "isDeleted": false,
   "artUrls": [
     "https://cdn.midjourney.com/4eea37a1-9ee1-4b3a-aa21-574e58368a36/0_2.png"
@@ -19,5 +19,11 @@
   "vittles": "",
   "pointsOfInterest": "",
   "floraFauna": "",
-  "lastModified": "2025-11-20T15:52:54.760Z"
+  "lastModified": "2025-11-20T15:52:54.760Z",
+  "heightMin": 4,
+  "heightMax": 5,
+  "weightMin": 125,
+  "weightMax": 400,
+  "lifespan": "75 years",
+  "speed": 30
 }

--- a/data/concepts/svirfneblin.json
+++ b/data/concepts/svirfneblin.json
@@ -2,7 +2,7 @@
   "id": "1c61dcb1-937a-44fe-9c69-3cd588e9dcb7",
   "conceptType": "ANCESTRY",
   "name": "Svirfneblin",
-  "description": "<p>The Svirfneblin share the Gnome's curiosity, but compressed and directed inward — down through layers of stone and precision, toward the very small and the very exact. They are most at home underground, carrying the careful stillness of people who have learned not to make unnecessary noise in the dark. They also have a constitutional tendency to speak at considerable length on subjects of personal interest, and to continue well past the point at which their audience has given up following.</p><p><strong><em>Height</em></strong><em>: 2-3' </em>| <strong><em>Weight</em></strong><em>: 20-75 lbs </em>| <strong><em>Average Lifespan</em></strong><em>: 200 years </em>| <strong><em>Speed</em></strong><em>: 20</em></p>",
+  "description": "<p>The Svirfneblin share the Gnome's curiosity, but compressed and directed inward — down through layers of stone and precision, toward the very small and the very exact. They are most at home underground, carrying the careful stillness of people who have learned not to make unnecessary noise in the dark. They also have a constitutional tendency to speak at considerable length on subjects of personal interest, and to continue well past the point at which their audience has given up following.</p>",
   "isDeleted": false,
   "artUrls": [
     "https://cdn.midjourney.com/63d1805a-ac93-410e-ae5d-4626c5194e29/0_0.png"
@@ -19,5 +19,11 @@
   "vittles": "",
   "pointsOfInterest": "",
   "floraFauna": "",
-  "lastModified": "2026-02-26T20:04:08.765Z"
+  "lastModified": "2026-02-26T20:04:08.765Z",
+  "heightMin": 2,
+  "heightMax": 3,
+  "weightMin": 20,
+  "weightMax": 75,
+  "lifespan": "200 years",
+  "speed": 20
 }

--- a/data/concepts/tritoni.json
+++ b/data/concepts/tritoni.json
@@ -2,7 +2,7 @@
   "id": "e40c3cff-9f6b-4940-ae41-cef878821a75",
   "conceptType": "ANCESTRY",
   "name": "Tritoni",
-  "description": "<p>The Tritoni are descended from creatures that chose the water but never surrendered the lung. Bipedal and broadly humanoid, they are built for the ocean in ways that become apparent on land. Their gills require daily attention above the waterline, and their movements are slower on dry ground than in open water.</p><p><strong><em>Height</em></strong><em>: 5-6' </em>| <strong><em>Weight</em></strong><em>: 125-400 lbs </em>| <strong><em>Average Lifespan</em></strong><em>: 70 years </em>| <strong><em>Speed</em></strong><em>: 30</em></p>",
+  "description": "<p>The Tritoni are descended from creatures that chose the water but never surrendered the lung. Bipedal and broadly humanoid, they are built for the ocean in ways that become apparent on land. Their gills require daily attention above the waterline, and their movements are slower on dry ground than in open water.</p>",
   "isDeleted": false,
   "artUrls": [
     "https://cdn.midjourney.com/10cd953d-17f2-4495-bf14-f6c9fe24a8b0/0_3.png"
@@ -19,5 +19,11 @@
   "vittles": "",
   "pointsOfInterest": "",
   "floraFauna": "",
-  "lastModified": "2026-02-25T19:47:48.462Z"
+  "lastModified": "2026-02-25T19:47:48.462Z",
+  "heightMin": 5,
+  "heightMax": 6,
+  "weightMin": 125,
+  "weightMax": 400,
+  "lifespan": "70 years",
+  "speed": 30
 }

--- a/data/users/arthurentropy.json
+++ b/data/users/arthurentropy.json
@@ -16,6 +16,6 @@
     "showArtwork": true
   },
   "characters": [],
-  "lastUpdatedAt": "2026-03-05T16:55:02.171Z",
-  "lastModified": "2026-04-20T13:39:42.885Z"
+  "lastUpdatedAt": "2026-04-20T14:54:27.261Z",
+  "lastModified": "2026-04-20T14:54:27.261Z"
 }

--- a/data/users/arthurentropy.json
+++ b/data/users/arthurentropy.json
@@ -7,7 +7,7 @@
   "status": "approved",
   "needsUsername": false,
   "createdAt": "2025-10-24T18:03:45.214Z",
-  "lastLoginAt": "2025-12-17T14:39:00.463Z",
+  "lastLoginAt": "2026-04-20T13:39:42.350Z",
   "isDeleted": false,
   "preferences": {
     "theme": "dark",
@@ -17,5 +17,5 @@
   },
   "characters": [],
   "lastUpdatedAt": "2026-03-05T16:55:02.171Z",
-  "lastModified": "2026-03-05T16:55:02.171Z"
+  "lastModified": "2026-04-20T13:39:42.885Z"
 }

--- a/packages/frontend/src/App.vue
+++ b/packages/frontend/src/App.vue
@@ -14,34 +14,16 @@
       </div>
 
       <nav v-if="menuOpen">
-        <router-link to="/rules" @click="closeMenu">RULES</router-link>
-        <router-link to="/ancestries" @click="closeMenu">ANCESTRIES</router-link>
-        <router-link to="/cultures" @click="closeMenu">CULTURES</router-link>
-        <router-link to="/world-elements" @click="closeMenu">WORLD ELEMENTS</router-link>
-        <router-link to="/mestieri" @click="closeMenu">MESTIERI</router-link>
-        <router-link v-if="authStore.isAuthenticated" to="/characters" @click="closeMenu">CHARACTERS</router-link>
-        <router-link to="/bestiary" @click="closeMenu">BESTIARY</router-link>
-        <router-link to="/abilities" @click="closeMenu">ABILITIES</router-link>
-        <router-link to="/equipment" @click="closeMenu">EQUIPMENT</router-link>
-        <router-link v-if="authStore.isAdmin" to="/art" @click="closeMenu">ART</router-link>
-        <router-link v-if="authStore.isAdmin" to="/tabletop">TABLETOP</router-link>
+        <router-link v-for="link in navLinks" :key="link.to" :to="link.to"
+          :class="{ 'router-link-active': isActiveSection(link.to) }" @click="closeMenu">{{ link.label }}</router-link>
       </nav>
     </div>
 
     <!-- Desktop Top Navigation -->
     <div class="top-nav">
       <div class="top-nav-content">
-        <router-link to="/rules">RULES</router-link>
-        <router-link to="/ancestries">ANCESTRIES</router-link>
-        <router-link to="/cultures">CULTURES</router-link>
-        <router-link to="/world-elements">WORLD ELEMENTS</router-link>
-        <router-link to="/mestieri">MESTIERI</router-link>
-        <router-link v-if="authStore.isAuthenticated" to="/characters">CHARACTERS</router-link>
-        <router-link to="/bestiary">BESTIARY</router-link>
-        <router-link to="/abilities">ABILITIES</router-link>
-        <router-link to="/equipment">EQUIPMENT</router-link>
-        <router-link v-if="authStore.isAdmin" to="/art">ART</router-link>
-        <router-link v-if="authStore.isAdmin" to="/tabletop">TABLETOP</router-link>
+        <router-link v-for="link in navLinks" :key="link.to" :to="link.to"
+          :class="{ 'router-link-active': isActiveSection(link.to) }">{{ link.label }}</router-link>
       </div>
 
       <!-- Desktop Auth Component -->
@@ -90,6 +72,21 @@ const authStore = useAuthStore()
 const userStore = useUserStore()
 const backgroundImagesStore = useBackgroundImagesStore()
 const shouldShowOverlay = computed(() => route.meta?.overlay === true)
+const isActiveSection = (path) => route.path === path || route.path.startsWith(path + '/')
+
+const navLinks = computed(() => [
+  { to: '/rules', label: 'RULES' },
+  { to: '/ancestries', label: 'ANCESTRIES' },
+  { to: '/cultures', label: 'CULTURES' },
+  { to: '/world-elements', label: 'WORLD ELEMENTS' },
+  { to: '/mestieri', label: 'MESTIERI' },
+  ...(authStore.isAuthenticated ? [{ to: '/characters', label: 'CHARACTERS' }] : []),
+  { to: '/bestiary', label: 'BESTIARY' },
+  { to: '/abilities', label: 'ABILITIES' },
+  { to: '/equipment', label: 'EQUIPMENT' },
+  ...(authStore.isAdmin ? [{ to: '/art', label: 'ART' }] : []),
+  ...(authStore.isAdmin ? [{ to: '/tabletop', label: 'TABLETOP' }] : []),
+])
 const showPreferencesModal = ref(false)
 
 // Compute selected background image from user preferences

--- a/packages/frontend/src/App.vue
+++ b/packages/frontend/src/App.vue
@@ -51,6 +51,8 @@
     </div>
 
   </div>
+
+  <CardPreviewOverlay />
 </template>
 
 <script setup>
@@ -65,6 +67,7 @@ import AuthComponent from '@/components/features/auth/AuthComponent.vue'
 import UsernameSetup from '@/components/features/auth/UsernameSetup.vue'
 import NotInvitedModal from '@/components/features/auth/NotInvitedModal.vue'
 import PreferencesModal from '@/components/features/preferences/PreferencesModal.vue'
+import CardPreviewOverlay from '@/components/ui/cards/preview/CardPreviewOverlay.vue'
 
 const menuOpen = ref(false)
 const route = useRoute()

--- a/packages/frontend/src/components/editModals/EditEquipmentModal.vue
+++ b/packages/frontend/src/components/editModals/EditEquipmentModal.vue
@@ -51,7 +51,7 @@
               <label for="equipmentType" class="left-aligned">Type:</label>
               <select id="equipmentType" v-model="editedEquipment.type" class="modal-input" @change="onTypeChange">
                 <option value="">-- Select Type --</option>
-                <option v-for="type in equipmentTypes" :key="type.id" :value="type.id">
+                <option v-for="type in equipmentTypesStore.items" :key="type.id" :value="type.id">
                   {{ type.name }}
                 </option>
               </select>
@@ -74,7 +74,7 @@
               <label for="equipmentGrade" class="left-aligned">Grade:</label>
               <select id="equipmentGrade" v-model="editedEquipment.grade" class="modal-input">
                 <option value="">-- Select Grade --</option>
-                <option v-for="grade in equipmentGrades" :key="grade.id" :value="grade.id">
+                <option v-for="grade in equipmentGradesStore.items" :key="grade.id" :value="grade.id">
                   {{ grade.name }}
                 </option>
               </select>
@@ -106,7 +106,7 @@
               <label for="range" class="left-aligned">Range:</label>
               <select id="range" v-model="editedEquipment.range" class="modal-input">
                 <option value="">-- Select Range --</option>
-                <option v-for="range in equipmentRanges" :key="range.id" :value="range.id">
+                <option v-for="range in equipmentRangesStore.items" :key="range.id" :value="range.id">
                   {{ range.name }} ({{ range.distance }})
                 </option>
               </select>
@@ -125,7 +125,7 @@
             <div class="form-column">
               <label for="keeping" class="left-aligned">Keeping:</label>
               <select id="keeping" v-model="editedEquipment.keeping" class="modal-input">
-                <option v-for="keeping in keepingOptions" :key="keeping.id" :value="keeping.id">
+                <option v-for="keeping in keepingStore.keeping" :key="keeping.id" :value="keeping.id">
                   {{ keeping.name }} ({{ keeping.cost }})
                 </option>
               </select>
@@ -181,7 +181,7 @@
           <div v-if="equipmentIsWeapon" class="form-group vertical">
             <label>Engagement Successes:</label>
             <div class="properties-inline">
-              <label v-for="success in engagementSuccessOptions" :key="success.id" :for="'success-' + success.id"
+              <label v-for="success in engagementSuccessesStore.items" :key="success.id" :for="'success-' + success.id"
                 class="property-checkbox">
                 <input type="checkbox" :id="'success-' + success.id" :value="success.id"
                   v-model="editedEquipment.engagementSuccesses" />
@@ -251,6 +251,12 @@ import ActionButton from '@/components/ui/buttons/ActionButton.vue'
 import { useEditModalForm } from '@/composables/useEditModalForm'
 import { getDiceFontMaxClass } from '@/utils/diceFontUtils'
 import { STANDARD_DIE_SIZES } from '@shared/constants/dice'
+import { useEquipmentTypesStore } from '@/stores/equipmentTypesStore'
+import { useEquipmentSubtypesStore } from '@/stores/equipmentSubtypesStore'
+import { useEquipmentGradesStore } from '@/stores/equipmentGradesStore'
+import { useEquipmentRangesStore } from '@/stores/equipmentRangesStore'
+import { useKeepingStore } from '@/stores/keepingStore'
+import { useEngagementSuccessesStore } from '@/stores/engagementSuccessesStore'
 
 
 // Props
@@ -259,34 +265,6 @@ const props = defineProps({
     type: Object,
     required: true,
   },
-  allEquipment: {
-    type: Array,
-    default: () => [],
-  },
-  keepingOptions: {
-    type: Array,
-    default: () => [],
-  },
-  equipmentTypes: {
-    type: Array,
-    default: () => [],
-  },
-  equipmentSubtypes: {
-    type: Array,
-    default: () => [],
-  },
-  equipmentGrades: {
-    type: Array,
-    default: () => [],
-  },
-  equipmentRanges: {
-    type: Array,
-    default: () => [],
-  },
-  engagementSuccessOptions: {
-    type: Array,
-    default: () => [],
-  },
 })
 
 // Emits
@@ -294,6 +272,14 @@ const emit = defineEmits(['update', 'delete', 'close'])
 
 // Use edit modal form composable
 const { editedData: editedEquipment, save: baseSave, deleteItem, handleOverlayClick } = useEditModalForm(props, emit)
+
+// Stores
+const equipmentTypesStore = useEquipmentTypesStore()
+const equipmentSubtypesStore = useEquipmentSubtypesStore()
+const equipmentGradesStore = useEquipmentGradesStore()
+const equipmentRangesStore = useEquipmentRangesStore()
+const keepingStore = useKeepingStore()
+const engagementSuccessesStore = useEngagementSuccessesStore()
 
 // Dice management - convert between array [4, 6, 6, 8] and count object {4: 1, 6: 2, 8: 1}
 const dieTypes = STANDARD_DIE_SIZES
@@ -325,14 +311,14 @@ damageDiceCounts.value = convertArrayToCounts(editedEquipment.value?.damageDice 
 // Computed properties
 const equipmentIsWeapon = computed(() => {
   if (!editedEquipment.value?.type) return false
-  const equipmentType = props.equipmentTypes.find(t => t.id === editedEquipment.value.type)
+  const equipmentType = equipmentTypesStore.items.find(t => t.id === editedEquipment.value.type)
   return equipmentType?.name === 'Weapon'
 })
 
 // Equipment categories management
 const availableSubtypes = computed(() => {
   if (!editedEquipment.value?.type) return []
-  return props.equipmentSubtypes.filter(subtype => subtype.typeId === editedEquipment.value.type)
+  return equipmentSubtypesStore.items.filter(subtype => subtype.typeId === editedEquipment.value.type)
 })
 
 const onTypeChange = () => {

--- a/packages/frontend/src/components/features/characterSheet/CharacterSheet.vue
+++ b/packages/frontend/src/components/features/characterSheet/CharacterSheet.vue
@@ -1,25 +1,23 @@
 <template>
-    <div class="modal-overlay" @click.self="handleClose">
-        <div class="modal-content">
-            <div class="scrollable-wrapper">
+    <div class="character-sheet">
+        <div class="character-sheet-content">
 
-                <!-- Top Row -->
-                <div class="top-section">
-                    <CharacterProfile @close-sheet="handleClose" />
-                    <DiceBox />
-                    <EngagementTable :can-edit="canEdit" />
-                </div>
+            <!-- Top Row -->
+            <div class="top-section">
+                <CharacterProfile @close-sheet="handleClose" />
+                <DiceBox />
+                <EngagementTable :can-edit="canEdit" />
+            </div>
 
-                <!-- Character Stats and Details -->
-                <div class="character-stats-section">
-                    <CoreAbilityColumn :column="CORE_ABILITIES.BODY" />
-                    <CoreAbilityColumn :column="CORE_ABILITIES.HEART" />
-                    <CoreAbilityColumn :column="CORE_ABILITIES.WITS" />
-                    <ConditionsColumn :is-edit-mode="canEdit" />
-                    <EquipmentTable :is-edit-mode="canEdit" />
-                    <AbilitiesTable :canEdit="canEdit" />
-                    <BiomeSection v-if="showBiomeSection" />
-                </div>
+            <!-- Character Stats and Details -->
+            <div class="character-stats-section">
+                <CoreAbilityColumn :column="CORE_ABILITIES.BODY" />
+                <CoreAbilityColumn :column="CORE_ABILITIES.HEART" />
+                <CoreAbilityColumn :column="CORE_ABILITIES.WITS" />
+                <ConditionsColumn :is-edit-mode="canEdit" />
+                <EquipmentTable :is-edit-mode="canEdit" />
+                <AbilitiesTable :canEdit="canEdit" />
+                <BiomeSection v-if="showBiomeSection" />
             </div>
         </div>
     </div>
@@ -64,24 +62,16 @@ const handleClose = () => {
 </script>
 
 <style scoped>
-.modal-content {
-    background: var(--overlay-black-heavy);
-    border-radius: var(--radius-5);
-    max-width: 1120px;
-    position: relative;
-    margin-top: -7px;
+.character-sheet {
+    width: 100%;
     padding: var(--space-lg);
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    max-height: calc(100vh - 2 * var(--space-lg));
 }
 
-.scrollable-wrapper {
-    width: 100%;
-    max-height: 100%;
-    overflow-y: auto;
-    overflow-x: visible;
+.character-sheet-content {
+    border-radius: var(--radius-5);
+    max-width: 1120px;
+    margin: 0 auto;
+    padding: var(--space-lg);
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -119,15 +109,13 @@ const handleClose = () => {
 }
 
 @media (max-width: var(--breakpoint-sm)) {
-    .modal-content {
-        margin: 0;
-        max-height: 100vh;
-        border-radius: 0;
+    .character-sheet {
         padding: var(--space-md);
     }
 
-    .scrollable-wrapper {
-        max-height: calc(100vh - 2 * var(--space-md));
+    .character-sheet-content {
+        border-radius: 0;
+        padding: var(--space-md);
     }
 }
 </style>

--- a/packages/frontend/src/components/features/characterSheet/abilitiesTable/AbilitiesTable.vue
+++ b/packages/frontend/src/components/features/characterSheet/abilitiesTable/AbilitiesTable.vue
@@ -7,11 +7,14 @@
       <template #header-left>
         <FloatingActionButton v-if="internalEditMode" type="add" size="small" visibility="always"
           @click="toggleAbilitySelector" />
+        <ActionButton v-if="internalEditMode && groupingOption === 'custom'" variant="outline" size="small"
+          text="+ Group" @click="createAbilityGroup" />
       </template>
       <template #header-center>
-        <div v-show="!isCollapsed" class="header-controls">
-          <SortingDropdown v-model="groupingOption" :options="groupingOptions" placeholder="Group by..." />
-          <SortingDropdown v-model="abilitySortOption" :options="sortOptions" placeholder="Order by..." />
+        <div v-if="internalEditMode" v-show="!isCollapsed" class="header-controls">
+          <SortingDropdown v-model="groupingOption" :options="groupingOptions" label="Group by:"
+            placeholder="Ungrouped" />
+          <SortingDropdown v-model="abilitySortOption" :options="sortOptions" label="Order by:" placeholder="Custom" />
         </div>
       </template>
       <template #header-right>
@@ -31,31 +34,34 @@
       </div>
 
       <!-- Grouped Display -->
-      <GroupedMasonryGrid v-else-if="hasAbilityGrouping" :column-width="350" :gap="20" :row-height="10"
-        :grouped-items="groupedAbilities" class="abilities-masonry" ref="masonryGridRef">
+      <GroupedThreeColumnLayout v-else-if="hasAbilityGrouping" :grouped-items="groupedAbilities"
+        :draggable="isDraggable" :custom-group-mode="groupingOption === 'custom'" custom-group-id="ability-custom-group"
+        @reorder-group="onAbilityGroupReorder" @rename-group="renameAbilityGroup" @delete-group="deleteAbilityGroup">
         <template #default="{ item }">
-          <AbilityCard v-if="item" :ability="item" :collapsed="item.collapsed" class="ability-card" :collapsible="false"
+          <AbilityCard v-if="item" :ability="item" :collapsed="item.collapsed" class="ability-card" :collapsible="true"
             :show-xp-badge="true" :show-add-to-character="false" :show-action-buttons="true"
             :character="selectedCharacter" :show-improvement-toggle="true" :show-improvements="item.showImprovements"
-            @update="handleCharacterUpdate" @update:showImprovements="updateAbilityShowImprovements(item, $event)"
-            :show-successes="item.showSuccesses" @update:showSuccesses="updateAbilityShowSuccesses(item, $event)"
-            @roll-link="handleRollLink" />
+            @update="handleCharacterUpdate" @update:collapsed="updateAbilityCollapsed(item.id, $event)"
+            @update:showImprovements="updateAbilityShowImprovements(item, $event)" :show-successes="item.showSuccesses"
+            @update:showSuccesses="updateAbilityShowSuccesses(item, $event)" @roll-link="handleRollLink" />
           <span v-else class="missing-item">Unknown ability</span>
         </template>
-      </GroupedMasonryGrid>
+      </GroupedThreeColumnLayout>
 
       <!-- Ungrouped Display -->
-      <MasonryGrid v-else :column-width="350" :gap="20" :row-height="10" class="abilities-masonry" ref="masonryGridRef">
-        <div v-for="ability in characterAbilities" :key="ability.id" class="masonry-item">
+      <ThreeColumnLayout v-else :items="characterAbilities" :is-draggable="isDraggable" group-id="abilities"
+        @reorder="handleAbilityReorder">
+        <template #default="{ item: ability }">
           <AbilityCard v-if="ability" :ability="ability" :collapsed="ability.collapsed" class="ability-card"
-            :collapsible="false" :show-xp-badge="true" :show-add-to-character="false" :show-action-buttons="true"
+            :collapsible="true" :show-xp-badge="true" :show-add-to-character="false" :show-action-buttons="true"
             :character="selectedCharacter" :show-improvement-toggle="true" :show-improvements="ability.showImprovements"
-            @update="handleCharacterUpdate" @update:showImprovements="updateAbilityShowImprovements(ability, $event)"
+            @update="handleCharacterUpdate" @update:collapsed="updateAbilityCollapsed(ability.id, $event)"
+            @update:showImprovements="updateAbilityShowImprovements(ability, $event)"
             :show-successes="ability.showSuccesses" @update:showSuccesses="updateAbilityShowSuccesses(ability, $event)"
             @roll-link="handleRollLink" />
           <span v-else class="missing-item">Unknown ability</span>
-        </div>
-      </MasonryGrid>
+        </template>
+      </ThreeColumnLayout>
     </div>
 
     <!-- Add Ability Selector Modal -->
@@ -73,20 +79,22 @@
 </template>
 
 <script setup>
-import { computed, ref, onMounted, watch } from 'vue'
+import { computed, ref } from 'vue'
 import AbilityCard from '@/components/ui/cards/item/AbilityCard.vue'
+import ActionButton from '@/components/ui/buttons/ActionButton.vue'
 import TableHeader from '@/components/ui/tables/TableHeader.vue'
 import FloatingActionButton from '@/components/ui/buttons/FloatingActionButton.vue'
 import ItemSelector from '@/components/ui/selectors/ItemSelector.vue'
 import CharacterSheetSection from '@/components/ui/containers/CharacterSheetSection.vue'
 import MPDisplay from './MPDisplay.vue'
-import GroupedMasonryGrid from '@/components/ui/layouts/GroupedMasonryGrid.vue'
-import MasonryGrid from '@/components/ui/layouts/MasonryGrid.vue'
+import ThreeColumnLayout from '@/components/ui/layouts/ThreeColumnLayout.vue'
+import GroupedThreeColumnLayout from '@/components/ui/layouts/GroupedThreeColumnLayout.vue'
 import SortingDropdown from '@/components/ui/dropdowns/SortingDropdown.vue'
 import SkillCheckModal from '@/components/features/characterSheet/modals/SkillCheckModal.vue'
 import CharacterService from '@/services/entities/characterService'
 import { useItemSelector } from '@/composables/useItemSelector'
 import { useItemGrouping } from '@/composables/useItemGrouping'
+import { useCustomGroupManagement } from '@/composables/useCustomGroupManagement'
 import { sortItems } from '@/utils/sortItems'
 import { ABILITY_SORT_OPTIONS } from '@/constants/sortOptions'
 import { useCharactersStore } from '@/stores/charactersStore'
@@ -117,8 +125,6 @@ const isChanneler = computed(() => {
   return mestiere?.name?.toLowerCase() === 'channeler'
 })
 
-const masonryGridRef = ref(null)
-
 const rollsStore = useRollsStore()
 
 // Roll link modal refs
@@ -130,9 +136,12 @@ const rollLinkBiomeDiceMod = ref(0)
 const sortOptions = ABILITY_SORT_OPTIONS
 
 const groupingOptions = computed(() => {
-  const options = [{ value: 'source', label: 'Source' }]
+  const options = [
+    { value: 'source', label: 'Source' },
+    { value: 'custom', label: 'Custom' },
+  ]
   if (isChanneler.value) {
-    options.push({ value: 'mana-color', label: 'Mana Color' })
+    options.splice(1, 0, { value: 'mana-color', label: 'Mana Color' })
   }
   return options
 })
@@ -141,19 +150,22 @@ const groupingOptions = computed(() => {
 const groupingOption = computed({
   get: () => {
     if (selectedCharacter.value?.groupAbilitiesByManaColor) return 'mana-color'
+    if (selectedCharacter.value?.groupAbilitiesByCustom) return 'custom'
     if (selectedCharacter.value?.groupAbilitiesBySource) return 'source'
     return ''
   },
   set: (value) => {
+    // All three flags are set explicitly to ensure they are mutually exclusive
     if (selectedCharacter.value) {
       selectedCharacter.value.groupAbilitiesBySource = (value === 'source')
       selectedCharacter.value.groupAbilitiesByManaColor = (value === 'mana-color')
+      selectedCharacter.value.groupAbilitiesByCustom = (value === 'custom')
     }
   }
 })
 
 const abilitySortOption = computed({
-  get: () => selectedCharacter.value?.abilitySortOption || 'name-asc',
+  get: () => selectedCharacter.value?.abilitySortOption || '',
   set: (value) => {
     if (selectedCharacter.value) {
       selectedCharacter.value.abilitySortOption = value
@@ -168,6 +180,20 @@ const toggleEditMode = () => { internalEditMode.value = !internalEditMode.value 
 
 const canEdit = computed(() => props.canEdit)
 
+// Drag is enabled only when no sort option is active (custom order mode)
+const isDraggable = computed(() => !abilitySortOption.value)
+
+// Custom groups stored on the character, exposed as a computed ref for useItemGrouping
+const abilityCustomGroups = computed(() => selectedCharacter.value?.abilityCustomGroups ?? [])
+
+const {
+  handleFlatReorder: handleAbilityReorder,
+  onGroupReorder: onAbilityGroupReorder,
+  createGroup: createAbilityGroup,
+  renameGroup: renameAbilityGroup,
+  deleteGroup: deleteAbilityGroup
+} = useCustomGroupManagement(selectedCharacter, 'abilities', 'abilityCustomGroups', groupingOption)
+
 const sourcesStore = useSourcesStore()
 
 const characterAbilities = computed(() => {
@@ -175,7 +201,7 @@ const characterAbilities = computed(() => {
   if (!selectedCharacter.value?.abilities) return []
 
   const abilities = selectedCharacter.value.abilities
-    ?.map((abilityObj) => {
+    ?.map((abilityObj, index) => {
       const ability = allAbilitiesArray.find((a) => a.id === abilityObj.id)
       if (!ability) return null
 
@@ -188,7 +214,8 @@ const characterAbilities = computed(() => {
         characterImprovements: characterImprovements || {},
         collapsed: abilityObj.collapsed ?? true,
         showImprovements: abilityObj.showImprovements ?? false,
-        showSuccesses: abilityObj.showSuccesses ?? false
+        showSuccesses: abilityObj.showSuccesses ?? false,
+        columnIndex: abilityObj.columnIndex ?? (index % 3)
       }
     })
     .filter((ability) => ability !== null) || []
@@ -210,12 +237,9 @@ const {
 const { groupedItems: groupedAbilities, hasGrouping: hasAbilityGrouping } = useItemGrouping(
   characterAbilities,
   groupingOption,
-  sourcesStore
+  sourcesStore,
+  abilityCustomGroups
 )
-
-watch(characterAbilities, () => {
-  masonryGridRef.value?.updateLayout()
-}, { deep: true })
 
 const selectAbility = (ability) => {
   const updated = CharacterService.addItem(selectedCharacter.value, 'abilities', {
@@ -241,6 +265,14 @@ const updateAbilityShowSuccesses = (ability, showSuccesses) => {
   const index = selectedCharacter.value.abilities.findIndex(a => a.id === ability.id)
   if (index !== -1) {
     selectedCharacter.value.abilities[index].showSuccesses = showSuccesses
+  }
+}
+
+const updateAbilityCollapsed = (abilityId, collapsed) => {
+  if (!selectedCharacter.value?.abilities) return
+  const index = selectedCharacter.value.abilities.findIndex(a => a.id === abilityId)
+  if (index !== -1) {
+    selectedCharacter.value.abilities[index].collapsed = collapsed
   }
 }
 
@@ -357,11 +389,6 @@ function applyBiomeDiceMod(pool, mod) {
   }
   return result
 }
-
-onMounted(() => {
-  masonryGridRef.value?.updateLayout()
-})
-
 </script>
 
 <style scoped>

--- a/packages/frontend/src/components/features/characterSheet/abilitiesTable/AbilitiesTable.vue
+++ b/packages/frontend/src/components/features/characterSheet/abilitiesTable/AbilitiesTable.vue
@@ -416,7 +416,6 @@ function applyBiomeDiceMod(pool, mod) {
 .empty-table-state {
   padding: var(--space-2xl) var(--space-xl);
   text-align: center;
-  background: var(--color-bg-secondary);
   border-radius: var(--radius-4);
   margin: var(--space-lg) 0;
 }

--- a/packages/frontend/src/components/features/characterSheet/engagementTable/EngagementSuccessDisplay.vue
+++ b/packages/frontend/src/components/features/characterSheet/engagementTable/EngagementSuccessDisplay.vue
@@ -13,7 +13,7 @@
         </div>
 
         <!-- No Successes Message -->
-        <div v-if="successData.length === 0 && !isEditMode" class="no-successes-message">
+        <div v-if="successData.length === 0 && !isEditMode && diceData.length > 0" class="no-successes-message">
             No engagement successes available
         </div>
 
@@ -25,6 +25,7 @@
 
 <script setup>
 import { ref, nextTick } from 'vue'
+import { useEngagementRoll } from '@/composables/useEngagementRoll'
 import { useEngagementSuccesses } from '@/composables/useEngagementSuccesses'
 import { useFloatingElement } from '@/composables/useFloatingElement'
 import ChipTag from '@/components/ui/chips/ChipTag.vue'
@@ -38,6 +39,7 @@ defineProps({
     }
 })
 
+const diceData = useEngagementRoll().allOwnedEngagementDice
 const successManager = useEngagementSuccesses()
 const successData = successManager.allOwnedEngagementSuccesses
 const availableSuccesses = successManager.availableEngagementSuccesses

--- a/packages/frontend/src/components/features/characterSheet/equipmentTable/EquipmentTable.vue
+++ b/packages/frontend/src/components/features/characterSheet/equipmentTable/EquipmentTable.vue
@@ -522,7 +522,6 @@ onMounted(async () => {
 .empty-table-state {
   padding: var(--space-2xl) var(--space-xl);
   text-align: center;
-  background: var(--color-bg-secondary);
   border-radius: var(--radius-4);
   margin: var(--space-lg) 0;
 }

--- a/packages/frontend/src/components/features/characterSheet/equipmentTable/EquipmentTable.vue
+++ b/packages/frontend/src/components/features/characterSheet/equipmentTable/EquipmentTable.vue
@@ -5,11 +5,15 @@
       <template #header-left>
         <FloatingActionButton v-if="internalEditMode" type="add" size="small" visibility="always"
           @click="showEquipmentSelector = true" />
+        <ActionButton v-if="internalEditMode && groupingOption === 'custom'" variant="outline" size="small"
+          text="+ Group" @click="createEquipmentGroup" />
       </template>
       <template #header-center>
-        <div v-show="!isCollapsed" class="header-controls">
-          <SortingDropdown v-model="groupingOption" :options="groupingOptions" placeholder="Group by..." />
-          <SortingDropdown v-model="equipmentSortOption" :options="sortOptions" placeholder="Order by..." />
+        <div v-if="internalEditMode" v-show="!isCollapsed" class="header-controls">
+          <SortingDropdown v-model="groupingOption" :options="groupingOptions" label="Group by:"
+            placeholder="Ungrouped" />
+          <SortingDropdown v-model="equipmentSortOption" :options="sortOptions" label="Order by:"
+            placeholder="Custom" />
         </div>
       </template>
       <template #header-right>
@@ -25,39 +29,46 @@
       </div>
 
       <!-- Grouped Display -->
-      <GroupedMasonryGrid v-else-if="hasEquipmentGrouping" :column-width="350" :gap="20" :row-height="10"
-        :grouped-items="groupedEquipmentItems" class="equipment-masonry" ref="masonryGridRef">
+      <GroupedThreeColumnLayout v-else-if="hasEquipmentGrouping" :grouped-items="groupedEquipmentItems"
+        :draggable="isDraggable" :custom-group-mode="groupingOption === 'custom'"
+        custom-group-id="equipment-custom-group" @reorder-group="onEquipmentGroupReorder"
+        @rename-group="renameEquipmentGroup" @delete-group="deleteEquipmentGroup">
         <template #default="{ item }">
-          <EquipmentCard v-if="item.equipment" :equipment="item.equipment" :collapsed="item.collapsed || false"
-            :editable="item.equipment.isCustom" class="equipment-card" @edit="openEditEquipmentModal"
-            @update="handleCharacterUpdate" :collapsible="false" :show-keeping-badge="true"
-            :character="selectedCharacter" :show-improvement-toggle="true" :show-improvements="item.showImprovements"
-            @update:showImprovements="updateEquipmentShowImprovements(item, $event)" :engagement-success-options="[]"
-            :enable-damage-roll="true" @roll-damage="handleDamageRoll" @roll-link="handleRollLink" />
+          <template v-if="item.equipment">
+            <EquipmentCard :equipment="item.equipment" :collapsed="item.collapsed || false"
+              :editable="item.equipment.isCustom" class="equipment-card" @edit="openEditEquipmentModal"
+              @update="handleCharacterUpdate" :collapsible="true" :show-keeping-badge="true"
+              :character="selectedCharacter" :show-improvement-toggle="true" :show-improvements="item.showImprovements"
+              @update:collapsed="updateEquipmentCollapsed(item.id, $event)"
+              @update:showImprovements="updateEquipmentShowImprovements(item, $event)" :engagement-success-options="[]"
+              :enable-damage-roll="true" @roll-damage="handleDamageRoll" @roll-link="handleRollLink" />
+            <EquipmentDetails :equipment-item="item" :item-id="item.id" :is-edit-mode="canEdit"
+              @update-carried="handleCarriedChange" @update-wielding="handleWieldingChange"
+              @update-quantity="handleQuantityChange" />
+          </template>
           <span v-else class="missing-item">Unknown item</span>
-
-          <EquipmentDetails v-if="item.equipment" :equipment-item="item" :item-id="item.id" :is-edit-mode="canEdit"
-            @update-carried="handleCarriedChange" @update-wielding="handleWieldingChange"
-            @update-quantity="handleQuantityChange" />
         </template>
-      </GroupedMasonryGrid>
+      </GroupedThreeColumnLayout>
 
       <!-- Ungrouped Display -->
-      <MasonryGrid v-else :column-width="350" :gap="20" :row-height="10" class="equipment-masonry" ref="masonryGridRef">
-        <div v-for="item in characterEquipment" :key="item.id" class="masonry-item">
-          <EquipmentCard v-if="item.equipment" :equipment="item.equipment" :collapsed="item.collapsed || false"
-            :editable="item.equipment.isCustom" class="equipment-card" @edit="openEditEquipmentModal"
-            @update="handleCharacterUpdate" :collapsible="false" :show-keeping-badge="true"
-            :character="selectedCharacter" :show-improvement-toggle="true" :show-improvements="item.showImprovements"
-            @update:showImprovements="updateEquipmentShowImprovements(item, $event)" :engagement-success-options="[]"
-            :enable-damage-roll="true" @roll-damage="handleDamageRoll" @roll-link="handleRollLink" />
+      <ThreeColumnLayout v-else :items="characterEquipment" :is-draggable="isDraggable" group-id="equipment"
+        @reorder="handleEquipmentReorder">
+        <template #default="{ item }">
+          <template v-if="item.equipment">
+            <EquipmentCard :equipment="item.equipment" :collapsed="item.collapsed || false"
+              :editable="item.equipment.isCustom" class="equipment-card" @edit="openEditEquipmentModal"
+              @update="handleCharacterUpdate" :collapsible="true" :show-keeping-badge="true"
+              :character="selectedCharacter" :show-improvement-toggle="true" :show-improvements="item.showImprovements"
+              @update:collapsed="updateEquipmentCollapsed(item.id, $event)"
+              @update:showImprovements="updateEquipmentShowImprovements(item, $event)" :engagement-success-options="[]"
+              :enable-damage-roll="true" @roll-damage="handleDamageRoll" @roll-link="handleRollLink" />
+            <EquipmentDetails :equipment-item="item" :item-id="item.id" :is-edit-mode="canEdit"
+              @update-carried="handleCarriedChange" @update-wielding="handleWieldingChange"
+              @update-quantity="handleQuantityChange" />
+          </template>
           <span v-else class="missing-item">Unknown item</span>
-
-          <EquipmentDetails v-if="item.equipment" :equipment-item="item" :item-id="item.id" :is-edit-mode="canEdit"
-            @update-carried="handleCarriedChange" @update-wielding="handleWieldingChange"
-            @update-quantity="handleQuantityChange" />
-        </div>
-      </MasonryGrid>
+        </template>
+      </ThreeColumnLayout>
     </div>
 
     <!-- Equipment Selector Modal -->
@@ -84,7 +95,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, watch, nextTick } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import EquipmentCard from '@/components/ui/cards/item/EquipmentCard.vue'
 import EquipmentWeight from './EquipmentWeight.vue'
 import EquipmentDetails from './EquipmentDetails.vue'
@@ -93,14 +104,16 @@ import FloatingActionButton from '@/components/ui/buttons/FloatingActionButton.v
 import ItemSelector from '@/components/ui/selectors/ItemSelector.vue'
 import CharacterSheetSection from '@/components/ui/containers/CharacterSheetSection.vue'
 import EditEquipmentModal from '@/components/editModals/EditEquipmentModal.vue'
-import GroupedMasonryGrid from '@/components/ui/layouts/GroupedMasonryGrid.vue'
-import MasonryGrid from '@/components/ui/layouts/MasonryGrid.vue'
+import ThreeColumnLayout from '@/components/ui/layouts/ThreeColumnLayout.vue'
+import GroupedThreeColumnLayout from '@/components/ui/layouts/GroupedThreeColumnLayout.vue'
 import SortingDropdown from '@/components/ui/dropdowns/SortingDropdown.vue'
+import ActionButton from '@/components/ui/buttons/ActionButton.vue'
 import SkillCheckModal from '@/components/features/characterSheet/modals/SkillCheckModal.vue'
 import { useEditModal } from '@/composables/useEditModal'
 import CharacterService from '@/services/entities/characterService'
 import { useItemSelector } from '@/composables/useItemSelector'
 import { useItemGrouping } from '@/composables/useItemGrouping'
+import { useCustomGroupManagement } from '@/composables/useCustomGroupManagement'
 import { sortItems } from '@/utils/sortItems'
 import { EQUIPMENT_SORT_OPTIONS } from '@/constants/sortOptions'
 import { useEquipmentTypesStore } from '@/stores/equipmentTypesStore'
@@ -156,26 +169,42 @@ const rollLinkRollType = ref(null)
 
 const toggleEditMode = () => { internalEditMode.value = !internalEditMode.value }
 
-const masonryGridRef = ref(null)
-
 const sortOptions = EQUIPMENT_SORT_OPTIONS
 
 const groupingOptions = [
-  { value: 'source', label: 'Source' }
+  { value: 'source', label: 'Source' },
+  { value: 'custom', label: 'Custom' }
 ]
 
 // Grouping and Sorting state
 const groupingOption = computed({
-  get: () => selectedCharacter.value?.groupEquipmentBySource ? 'source' : '',
+  get: () => {
+    if (selectedCharacter.value?.groupEquipmentByCustom) return 'custom'
+    if (selectedCharacter.value?.groupEquipmentBySource) return 'source'
+    return ''
+  },
   set: (value) => {
+    // Both flags are set explicitly to ensure they are mutually exclusive
     if (selectedCharacter.value) {
       selectedCharacter.value.groupEquipmentBySource = (value === 'source')
+      selectedCharacter.value.groupEquipmentByCustom = (value === 'custom')
     }
   }
 })
 
+// Custom groups stored on the character, exposed as a computed ref for useItemGrouping
+const equipmentCustomGroups = computed(() => selectedCharacter.value?.equipmentCustomGroups ?? [])
+
+const {
+  handleFlatReorder: handleEquipmentReorder,
+  onGroupReorder: onEquipmentGroupReorder,
+  createGroup: createEquipmentGroup,
+  renameGroup: renameEquipmentGroup,
+  deleteGroup: deleteEquipmentGroup
+} = useCustomGroupManagement(selectedCharacter, 'equipment', 'equipmentCustomGroups', groupingOption)
+
 const equipmentSortOption = computed({
-  get: () => selectedCharacter.value?.equipmentSortOption || 'name-asc',
+  get: () => selectedCharacter.value?.equipmentSortOption || '',
   set: (value) => {
     if (selectedCharacter.value) {
       selectedCharacter.value.equipmentSortOption = value
@@ -184,6 +213,9 @@ const equipmentSortOption = computed({
 })
 
 const canEdit = computed(() => props.isEditMode)
+
+// Drag is enabled only when no sort option is active (custom order mode)
+const isDraggable = computed(() => !equipmentSortOption.value)
 
 const showEquipmentSelector = ref(false)
 const showChoiceMode = ref(true)
@@ -210,13 +242,14 @@ const { groupedItems: groupedEquipmentForSelector, searchQuery: equipmentSearchQ
 const characterEquipment = computed(() => {
   if (!selectedCharacter.value?.equipment) return []
 
-  const equipment = selectedCharacter.value.equipment.map((entry) => {
-    const equipment = allEquipment.value.find((eq) => eq.id === entry.id)
+  const equipment = selectedCharacter.value.equipment.map((entry, index) => {
+    const eq = allEquipment.value.find((eq) => eq.id === entry.id)
     return {
       ...entry,
-      equipment,
+      equipment: eq,
       collapsed: entry.collapsed ?? true,
       showImprovements: entry.showImprovements ?? false,
+      columnIndex: entry.columnIndex ?? (index % 3)
     }
   })
 
@@ -233,28 +266,19 @@ const characterEquipment = computed(() => {
       collapsed: original.collapsed,
       showImprovements: original.showImprovements,
       source: sorted.source,
-      equipment: sorted.equipment
+      equipment: sorted.equipment,
+      columnIndex: original.columnIndex,
+      customGroupId: original.customGroupId ?? null
     }
   })
 })
 
 const { groupedItems: groupedEquipmentItems, hasGrouping: hasEquipmentGrouping } = useItemGrouping(
   characterEquipment,
-  computed(() => !!selectedCharacter.value?.groupEquipmentBySource),
-  sourcesStore
+  groupingOption,
+  sourcesStore,
+  equipmentCustomGroups
 )
-
-watch(characterEquipment, () => {
-  masonryGridRef.value?.updateLayout()
-}, { deep: true })
-
-watch(isCollapsed, (newVal) => {
-  if (!newVal) {
-    nextTick(() => {
-      masonryGridRef.value?.updateLayout()
-    })
-  }
-})
 
 const isCreatingCustom = ref(false)
 
@@ -426,6 +450,14 @@ const updateEquipmentShowImprovements = (item, showImprovements) => {
   }
 }
 
+const updateEquipmentCollapsed = (itemId, collapsed) => {
+  if (!selectedCharacter.value?.equipment) return
+  const index = selectedCharacter.value.equipment.findIndex(e => e.id === itemId)
+  if (index !== -1) {
+    selectedCharacter.value.equipment[index].collapsed = collapsed
+  }
+}
+
 const saveEditedEquipment = async (updatedEquipment) => {
   await equipmentStore.update(updatedEquipment)
   closeEditEquipmentModal()
@@ -474,7 +506,6 @@ onMounted(async () => {
       equipmentGradesStore.fetch()
     ])
     engagementSuccessOptions.value = await EngagementSuccessService.getAll()
-    masonryGridRef.value?.updateLayout()
   } catch (error) {
     console.error('Error initializing EquipmentTable data:', error)
   }

--- a/packages/frontend/src/components/features/characterSheet/equipmentTable/EquipmentTable.vue
+++ b/packages/frontend/src/components/features/characterSheet/equipmentTable/EquipmentTable.vue
@@ -73,11 +73,8 @@
     </ItemSelector>
 
     <!-- Edit Equipment Modal -->
-    <EditEquipmentModal v-if="showEditEquipmentModal" :equipment="equipmentToEdit" :all-equipment="allEquipment"
-      :keeping-options="keepingStore.keeping" :sources="sourcesStore.sources"
-      :equipment-types="equipmentTypesStore.items" :equipment-subtypes="equipmentSubtypesStore.items"
-      :equipment-grades="equipmentGradesStore.items" :engagement-success-options="engagementSuccessOptions"
-      @update="saveEditedEquipment" @close="closeEditEquipmentModal" @delete="deleteEquipment" />
+    <EditEquipmentModal v-if="showEditEquipmentModal" :equipment="equipmentToEdit" @update="saveEditedEquipment"
+      @close="closeEditEquipmentModal" @delete="deleteEquipment" />
 
     <!-- Skill Check Modal -->
     <SkillCheckModal v-if="showSkillCheckModal" :selected-skill-name="rollLinkSkill" :character="selectedCharacter"

--- a/packages/frontend/src/components/features/conceptDetail/ConceptDetail.vue
+++ b/packages/frontend/src/components/features/conceptDetail/ConceptDetail.vue
@@ -29,6 +29,7 @@
           <div class="concept-description-cell">
             <ConceptTitle :is-edit-mode="isEditMode" />
             <ConceptDescription :is-edit-mode="isEditMode" />
+            <PhysiologySection v-if="layout.showPhysiology" :is-edit-mode="isEditMode" />
           </div>
         </div>
 
@@ -80,6 +81,7 @@
         <NovizioSection v-if="layout.showNovizio" :editable="isEditMode" />
         <ConceptTitle :is-edit-mode="isEditMode" />
         <ConceptDescription :is-edit-mode="isEditMode" />
+        <PhysiologySection v-if="layout.showPhysiology" :is-edit-mode="isEditMode" />
         <ConceptImageSection v-if="layout.showFaces" title="Faces" :is-edit-mode="isEditMode"
           :mode="IMAGE_GALLERY_MODES.AUTO" :auto-source-type="ART_TYPES.FACES" />
         <ConceptImageSection v-if="layout.showPlaces" title="Places" :is-edit-mode="isEditMode"
@@ -115,6 +117,7 @@ import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
 import FloatingActionButton from '@/components/ui/buttons/FloatingActionButton.vue'
 import ConceptTitle from './components/ConceptTitle.vue'
 import ConceptDescription from './components/sections/ConceptDescription.vue'
+import PhysiologySection from './components/sections/PhysiologySection.vue'
 import ConceptAbilitiesSection from './components/sections/ConceptAbilitiesSection.vue'
 import ConceptEquipmentSection from './components/sections/ConceptEquipmentSection.vue'
 import ConceptImageSection from './components/sections/ConceptImageSection.vue'

--- a/packages/frontend/src/components/features/conceptDetail/ConceptDetail.vue
+++ b/packages/frontend/src/components/features/conceptDetail/ConceptDetail.vue
@@ -99,11 +99,7 @@
       @close="closeEditAbilityModal" @delete="deleteAbility" />
 
     <!-- Edit Equipment Modal -->
-    <EditEquipmentModal v-if="showEditEquipmentModal" :equipment="selectedEquipment"
-      :all-equipment="equipmentStore.equipment" :keeping-options="keepingStore.keeping"
-      :equipment-types="equipmentTypesStore.items" :equipment-subtypes="equipmentSubtypesStore.items"
-      :equipment-grades="equipmentGradesStore.items" :equipment-ranges="equipmentRangesStore.items"
-      :engagement-success-options="engagementSuccessOptions" @update="saveEditedEquipment"
+    <EditEquipmentModal v-if="showEditEquipmentModal" :equipment="selectedEquipment" @update="saveEditedEquipment"
       @close="closeEditEquipmentModal" @delete="deleteEquipment" />
   </div>
 
@@ -206,7 +202,6 @@ const {
   confirmIfUnsaved
 } = useUnsavedChanges(emit, () => hasUnsavedSectionChanges.value)
 
-const engagementSuccessOptions = computed(() => engagementSuccessesStore.items)
 const selectedConcept = computed(() => conceptsStore.selectedConcept)
 
 const DETAIL_OVERLAY = 'rgba(0, 0, 0, 0.5)'

--- a/packages/frontend/src/components/features/conceptDetail/ConceptDetail.vue
+++ b/packages/frontend/src/components/features/conceptDetail/ConceptDetail.vue
@@ -336,10 +336,6 @@ onBeforeUnmount(() => {
 </script>
 
 <style scoped>
-.concept-detail {
-  --concept-modal-width: 1540px;
-}
-
 .concept-content {
   position: relative;
   z-index: var(--z-raised);

--- a/packages/frontend/src/components/features/conceptDetail/ConceptDetail.vue
+++ b/packages/frontend/src/components/features/conceptDetail/ConceptDetail.vue
@@ -1,5 +1,10 @@
 <template>
-  <div class="modal-overlay" @click.self="handleClose">
+  <div class="concept-detail">
+
+    <!-- Full-viewport background image -->
+    <Teleport to="body">
+      <div v-if="selectedConcept?.detailBackgroundImage" class="concept-detail-bg" :style="detailBackgroundStyle" />
+    </Teleport>
 
     <!-- Admin Controls -->
     <div class="admin-controls">
@@ -9,7 +14,7 @@
         @click="() => toggleEditMode()" />
     </div>
 
-    <div class="modal-content" :style="detailBackgroundStyle">
+    <div class="concept-content">
 
       <!-- Desktop Layout: Grid Rows -->
       <div v-if="isDesktop" class="concept-layout-grid">
@@ -122,7 +127,6 @@ import EditAbilityModal from '@/components/editModals/EditAbilityModal.vue'
 import EditEquipmentModal from '@/components/editModals/EditEquipmentModal.vue'
 
 // Composables
-import { useUnsavedChanges } from '@/composables/useUnsavedChanges'
 import { useEditModal } from '@/composables/useEditModal'
 
 // Store imports
@@ -152,7 +156,7 @@ const _props = defineProps({
 })
 
 // Emits
-const emit = defineEmits(['close'])
+defineEmits(['close'])
 
 // Stores
 const conceptsStore = useConceptsStore()
@@ -189,7 +193,6 @@ const showSettingsModal = ref(false)
 
 // Edit mode state
 const isEditMode = ref(false)
-const hasUnsavedSectionChanges = ref(false)
 
 const toggleEditMode = (onSave) => {
   if (isEditMode.value && onSave) {
@@ -197,10 +200,6 @@ const toggleEditMode = (onSave) => {
   }
   isEditMode.value = !isEditMode.value
 }
-
-const {
-  confirmIfUnsaved
-} = useUnsavedChanges(emit, () => hasUnsavedSectionChanges.value)
 
 const selectedConcept = computed(() => conceptsStore.selectedConcept)
 
@@ -232,11 +231,6 @@ const updateLayout = () => {
 }
 
 const isDesktop = computed(() => !isMobile.value)
-
-// Methods
-const handleClose = () => {
-  confirmIfUnsaved(() => emit('close'))
-}
 
 // Ability and Equipment modal methods
 const saveEditedAbility = async (editedAbility) => {
@@ -339,12 +333,23 @@ onBeforeUnmount(() => {
 </script>
 
 <style scoped>
-.modal-overlay {
+.concept-detail {
   --concept-modal-width: 1540px;
 }
 
-.modal-content {
+.concept-content {
+  position: relative;
+  z-index: var(--z-raised);
   width: var(--concept-modal-width);
+  max-width: 90%;
+  margin: 0 auto;
+}
+
+.concept-detail-bg {
+  position: fixed;
+  inset: 0;
+  z-index: var(--z-overlay);
+  pointer-events: none;
 }
 
 /* Outer wrapper — full-width column of rows */
@@ -404,7 +409,7 @@ onBeforeUnmount(() => {
 
 .admin-controls {
   position: fixed;
-  top: var(--space-lg);
+  top: calc(var(--nav-height) + var(--space-lg));
   right: var(--space-lg);
   z-index: var(--z-modal-controls);
   display: flex;

--- a/packages/frontend/src/components/features/conceptDetail/components/sections/ConceptAbilitiesSection.vue
+++ b/packages/frontend/src/components/features/conceptDetail/components/sections/ConceptAbilitiesSection.vue
@@ -4,8 +4,9 @@
             empty-message="No abilities added yet.">
 
             <template v-if="hasAbilities" #header-center>
-                <SortingDropdown v-model="groupingOption" :options="groupingOptions" placeholder="Group by..." />
-                <SortingDropdown v-model="sortOption" :options="sortOptions" placeholder="Order by..." />
+                <SortingDropdown v-model="groupingOption" :options="groupingOptions" label="Group by:"
+                    placeholder="Ungrouped" />
+                <SortingDropdown v-model="sortOption" :options="sortOptions" label="Order by:" />
             </template>
 
             <template v-if="isEditMode" #header-right>

--- a/packages/frontend/src/components/features/conceptDetail/components/sections/ConceptEquipmentSection.vue
+++ b/packages/frontend/src/components/features/conceptDetail/components/sections/ConceptEquipmentSection.vue
@@ -4,8 +4,9 @@
             empty-message="No equipment added yet.">
 
             <template v-if="hasEquipment" #header-center>
-                <SortingDropdown v-model="groupingOption" :options="groupingOptions" placeholder="Group by..." />
-                <SortingDropdown v-model="sortOption" :options="sortOptions" placeholder="Order by..." />
+                <SortingDropdown v-model="groupingOption" :options="groupingOptions" label="Group by:"
+                    placeholder="None" />
+                <SortingDropdown v-model="sortOption" :options="sortOptions" label="Order by:" />
             </template>
 
             <template v-if="isEditMode" #header-right>

--- a/packages/frontend/src/components/features/conceptDetail/components/sections/NovizioSection.vue
+++ b/packages/frontend/src/components/features/conceptDetail/components/sections/NovizioSection.vue
@@ -409,7 +409,7 @@ watch(concept, (newConcept) => {
 }
 
 .martial-label {
-  min-width: 80px;
+  min-width: 70px;
   font-weight: var(--font-weight-semibold);
   color: var(--color-text-primary);
 }

--- a/packages/frontend/src/components/features/conceptDetail/components/sections/PhysiologySection.vue
+++ b/packages/frontend/src/components/features/conceptDetail/components/sections/PhysiologySection.vue
@@ -1,0 +1,244 @@
+<template>
+    <div v-if="hasContent || isEditMode" class="physiology-section edit-hover-area">
+
+        <!-- Edit button -->
+        <FloatingActionButton v-if="isEditMode" type="edit" @click="toggleEdit" :is-active="isEditingPhysiology"
+            size="small" visibility="always" class="edit-button-overlay" />
+
+        <!-- Edit mode -->
+        <div v-if="isEditingPhysiology" class="physiology-edit">
+            <div class="physiology-edit-grid">
+                <div class="physiology-edit-field">
+                    <label class="physiology-edit-label">Height Min (ft)</label>
+                    <NumberInput v-model="localStats.heightMin" :min="0" :max="99" size="small" />
+                </div>
+                <div class="physiology-edit-field">
+                    <label class="physiology-edit-label">Height Max (ft)</label>
+                    <NumberInput v-model="localStats.heightMax" :min="0" :max="99" size="small" />
+                </div>
+                <div class="physiology-edit-field">
+                    <label class="physiology-edit-label">Weight Min (lbs)</label>
+                    <NumberInput v-model="localStats.weightMin" :min="0" :max="99999" size="small" />
+                </div>
+                <div class="physiology-edit-field">
+                    <label class="physiology-edit-label">Weight Max (lbs)</label>
+                    <NumberInput v-model="localStats.weightMax" :min="0" :max="99999" size="small" />
+                </div>
+                <div class="physiology-edit-field">
+                    <label class="physiology-edit-label">Avg. Lifespan</label>
+                    <input v-model="localStats.lifespan" type="text" class="modal-input physiology-input"
+                        placeholder="e.g. 90 years" />
+                </div>
+                <div class="physiology-edit-field">
+                    <label class="physiology-edit-label">Speed</label>
+                    <NumberInput v-model="localStats.speed" :min="0" :max="999" size="small" />
+                </div>
+            </div>
+            <div class="physiology-edit-buttons">
+                <ActionButton variant="neutral" size="small" text="Cancel" @click="cancelEdit" />
+            </div>
+        </div>
+
+        <!-- Display mode -->
+        <div v-else class="physiology-badges" :class="{ 'cursor-pointer': isEditMode }" @click="startEdit">
+            <div v-if="concept?.heightMin || concept?.heightMax" class="physiology-badge">
+                <span class="badge-label">Height</span>
+                <span class="badge-value">{{ concept.heightMin }}-{{ concept.heightMax }}'</span>
+            </div>
+            <div v-if="concept?.weightMin || concept?.weightMax" class="physiology-badge">
+                <span class="badge-label">Weight</span>
+                <span class="badge-value">{{ concept.weightMin }}-{{ concept.weightMax }} lbs</span>
+            </div>
+            <div v-if="concept?.lifespan" class="physiology-badge">
+                <span class="badge-label">Avg. Lifespan</span>
+                <span class="badge-value">{{ concept.lifespan }}</span>
+            </div>
+            <div v-if="concept?.speed" class="physiology-badge">
+                <span class="badge-label">Speed</span>
+                <span class="badge-value">{{ concept.speed }} ft</span>
+            </div>
+        </div>
+
+    </div>
+</template>
+
+<script setup>
+import { ref, computed, watch } from 'vue'
+import FloatingActionButton from '@/components/ui/buttons/FloatingActionButton.vue'
+import ActionButton from '@/components/ui/buttons/ActionButton.vue'
+import NumberInput from '@/components/ui/forms/NumberInput.vue'
+import { useConceptsStore } from '@/stores/conceptsStore'
+
+const props = defineProps({
+    isEditMode: {
+        type: Boolean,
+        default: false,
+    },
+})
+
+const conceptsStore = useConceptsStore()
+const concept = computed(() => conceptsStore.selectedConcept)
+
+const isEditingPhysiology = ref(false)
+
+const localStats = ref({
+    heightMin: concept.value?.heightMin ?? 0,
+    heightMax: concept.value?.heightMax ?? 0,
+    weightMin: concept.value?.weightMin ?? 0,
+    weightMax: concept.value?.weightMax ?? 0,
+    lifespan: concept.value?.lifespan ?? '',
+    speed: concept.value?.speed ?? 30,
+})
+
+const hasContent = computed(() => {
+    return !!(
+        concept.value?.heightMin ||
+        concept.value?.heightMax ||
+        concept.value?.weightMin ||
+        concept.value?.weightMax ||
+        concept.value?.lifespan ||
+        concept.value?.speed
+    )
+})
+
+const startEdit = () => {
+    if (!props.isEditMode) return
+    isEditingPhysiology.value = true
+}
+
+const toggleEdit = () => {
+    if (!props.isEditMode) return
+    if (isEditingPhysiology.value) {
+        saveStats()
+    } else {
+        startEdit()
+    }
+}
+
+const saveStats = async () => {
+    if (concept.value) {
+        concept.value.heightMin = localStats.value.heightMin
+        concept.value.heightMax = localStats.value.heightMax
+        concept.value.weightMin = localStats.value.weightMin
+        concept.value.weightMax = localStats.value.weightMax
+        concept.value.lifespan = localStats.value.lifespan
+        concept.value.speed = localStats.value.speed
+        await conceptsStore.update(concept.value)
+    }
+    isEditingPhysiology.value = false
+}
+
+const cancelEdit = () => {
+    localStats.value = {
+        heightMin: concept.value?.heightMin ?? 0,
+        heightMax: concept.value?.heightMax ?? 0,
+        weightMin: concept.value?.weightMin ?? 0,
+        weightMax: concept.value?.weightMax ?? 0,
+        lifespan: concept.value?.lifespan ?? '',
+        speed: concept.value?.speed ?? 30,
+    }
+    isEditingPhysiology.value = false
+}
+
+watch(
+    () => concept.value,
+    (newConcept) => {
+        if (!isEditingPhysiology.value) {
+            localStats.value = {
+                heightMin: newConcept?.heightMin ?? 0,
+                heightMax: newConcept?.heightMax ?? 0,
+                weightMin: newConcept?.weightMin ?? 0,
+                weightMax: newConcept?.weightMax ?? 0,
+                lifespan: newConcept?.lifespan ?? '',
+                speed: newConcept?.speed ?? 30,
+            }
+        }
+    },
+)
+</script>
+
+<style scoped>
+.physiology-section {
+    position: relative;
+}
+
+.physiology-badges {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: var(--space-sm);
+}
+
+.physiology-badge {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-xs);
+    background: var(--overlay-black-medium);
+    border: 1px solid var(--color-border-muted);
+    border-radius: var(--radius-10);
+    padding: var(--space-md) var(--space-sm);
+    text-align: center;
+}
+
+.badge-label {
+    color: var(--color-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    font-size: var(--font-size-11);
+}
+
+.badge-value {
+    color: var(--color-text-primary);
+    font-size: var(--font-size-24);
+    font-weight: 600;
+    line-height: 1.1;
+}
+
+.physiology-edit {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm);
+}
+
+.physiology-edit-grid {
+    display: grid;
+    grid-template-columns: repeat(6, 1fr);
+    gap: var(--space-sm);
+    align-items: end;
+}
+
+.physiology-edit-field {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xs);
+}
+
+.physiology-edit-label {
+    font-size: var(--font-size-12);
+    color: var(--color-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    white-space: nowrap;
+}
+
+.physiology-input {
+    width: 100%;
+}
+
+.physiology-edit-buttons {
+    display: flex;
+    gap: var(--space-sm);
+}
+
+.edit-button-overlay {
+    position: absolute;
+    top: 0;
+    right: 0;
+    z-index: 1;
+}
+
+.cursor-pointer {
+    cursor: pointer;
+}
+</style>

--- a/packages/frontend/src/components/features/conceptDetail/components/shared/ImageGallery.vue
+++ b/packages/frontend/src/components/features/conceptDetail/components/shared/ImageGallery.vue
@@ -76,12 +76,11 @@
       </div>
 
       <!-- Overlaid prev/next page buttons -->
-      <button v-if="totalThumbnailPages > 1" class="thumb-page-nav left" :disabled="thumbnailPage === 0"
-        @click="prevThumbnailPage" aria-label="Previous thumbnail page">
+      <button v-if="totalThumbnailPages > 1" class="thumb-page-nav left" @click="prevThumbnailPage"
+        aria-label="Previous thumbnail page">
         <ChevronLeftIcon class="nav-icon" />
       </button>
-      <button v-if="totalThumbnailPages > 1" class="thumb-page-nav right"
-        :disabled="thumbnailPage === totalThumbnailPages - 1" @click="nextThumbnailPage"
+      <button v-if="totalThumbnailPages > 1" class="thumb-page-nav right" @click="nextThumbnailPage"
         aria-label="Next thumbnail page">
         <ChevronRightIcon class="nav-icon" />
       </button>
@@ -90,8 +89,8 @@
 
     <!-- Thumbnail page dots -->
     <div v-if="totalThumbnailPages > 1" class="thumb-dots">
-      <span v-for="page in totalThumbnailPages" :key="page" class="thumb-dot"
-        :class="{ active: page - 1 === thumbnailPage }" @click="goToThumbnailPage(page - 1)"></span>
+      <span v-for="page in visibleDotPages" :key="page" class="thumb-dot" :class="{ active: page === thumbnailPage }"
+        @click="goToThumbnailPage(page)"></span>
     </div>
 
     <!-- Add Image Modal -->
@@ -178,19 +177,24 @@ const isManualOrCombined = computed(() =>
   props.mode === IMAGE_GALLERY_MODES.MANUAL || props.mode === IMAGE_GALLERY_MODES.COMBINED
 )
 
+// Thumbnail pagination constants
+const THUMBS_PER_PAGE = 5 // 5 columns × 1 row
+const MAX_VISIBLE_DOTS = 25
+const MAX_TOTAL_IMAGES = MAX_VISIBLE_DOTS * THUMBS_PER_PAGE
+
 // If auto mode, compute images from art store; else use provided images
 const displayImages = computed(() => {
   if (props.mode === IMAGE_GALLERY_MODES.AUTO && props.autoSourceId) {
     const autoImages = artStore.getByTypeAndSource(props.autoSourceType, props.autoSourceId)
-    return autoImages.map(item => item.url).filter(url => !props.excludeUrls.includes(url))
+    return autoImages.map(item => item.url).filter(url => !props.excludeUrls.includes(url)).slice(0, MAX_TOTAL_IMAGES)
   }
   if (props.mode === IMAGE_GALLERY_MODES.COMBINED && props.autoSourceId) {
     if (props.editable) return props.images
     const autoImages = artStore.getByTypeAndSource(props.autoSourceType, props.autoSourceId)
     const autoUrls = autoImages.map(a => a.url).filter(url => !props.images.includes(url))
-    return [...props.images, ...autoUrls]
+    return [...props.images, ...autoUrls.slice(0, MAX_TOTAL_IMAGES - props.images.length)]
   }
-  return props.images
+  return props.images.slice(0, MAX_TOTAL_IMAGES)
 })
 
 // Reactive state
@@ -230,8 +234,6 @@ const nextImage = () => {
 }
 
 // Thumbnail pagination
-const THUMBS_PER_PAGE = 5 // 5 columns × 1 row
-
 const thumbnailPage = ref(0)
 const slideDirection = ref('left')
 
@@ -257,17 +259,13 @@ const pagedLocalImages = computed({
 const globalIndex = (localIdx) => thumbnailPageStart.value + localIdx
 
 const prevThumbnailPage = () => {
-  if (thumbnailPage.value > 0) {
-    slideDirection.value = 'right'
-    thumbnailPage.value--
-  }
+  slideDirection.value = 'right'
+  thumbnailPage.value = (thumbnailPage.value - 1 + totalThumbnailPages.value) % totalThumbnailPages.value
 }
 
 const nextThumbnailPage = () => {
-  if (thumbnailPage.value < totalThumbnailPages.value - 1) {
-    slideDirection.value = 'left'
-    thumbnailPage.value++
-  }
+  slideDirection.value = 'left'
+  thumbnailPage.value = (thumbnailPage.value + 1) % totalThumbnailPages.value
 }
 
 const goToThumbnailPage = (page) => {
@@ -275,6 +273,24 @@ const goToThumbnailPage = (page) => {
   slideDirection.value = page > thumbnailPage.value ? 'left' : 'right'
   thumbnailPage.value = page
 }
+
+const visibleDotPages = computed(() => {
+  const total = totalThumbnailPages.value
+  if (total <= MAX_VISIBLE_DOTS) {
+    return Array.from({ length: total }, (_, i) => i)
+  }
+  const half = Math.floor(MAX_VISIBLE_DOTS / 2)
+  let start = thumbnailPage.value - half
+  let end = start + MAX_VISIBLE_DOTS - 1
+  if (start < 0) {
+    start = 0
+    end = MAX_VISIBLE_DOTS - 1
+  } else if (end >= total) {
+    end = total - 1
+    start = end - MAX_VISIBLE_DOTS + 1
+  }
+  return Array.from({ length: MAX_VISIBLE_DOTS }, (_, i) => start + i)
+})
 
 const openEditModal = () => {
   editImageUrl.value = localImages.value[selectedIndex.value]

--- a/packages/frontend/src/components/ui/NavigationControls.vue
+++ b/packages/frontend/src/components/ui/NavigationControls.vue
@@ -34,15 +34,7 @@ defineEmits(['navigate'])
 
 <style scoped>
 .navigation-controls {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 100%;
-    position: fixed;
-    top: 0;
-    left: 0;
-    height: 100%;
-    z-index: var(--z-modal);
+    display: contents;
 }
 
 .navigate-button {
@@ -102,6 +94,12 @@ defineEmits(['navigate'])
 
     .navigate-button.next {
         right: 5px;
+    }
+}
+
+@media (max-width: 1800px) {
+    .navigate-button {
+        display: none;
     }
 }
 </style>

--- a/packages/frontend/src/components/ui/cards/item/AbilityCard.vue
+++ b/packages/frontend/src/components/ui/cards/item/AbilityCard.vue
@@ -1,7 +1,8 @@
 <template>
   <base-card :item="ability" :metaInfo="traitOrMp" :collapsed="collapsed" :editable="editable"
     @edit="$emit('edit', ability)" :collapsible="collapsible" @update:collapsed="$emit('update:collapsed', $event)"
-    @roll-link="handleRollLinkWithBiome" :itemType="ItemType.ABILITY" :class="biomeLinkClass" :show-source="false">
+    @roll-link="handleRollLinkWithBiome" :itemType="ItemType.ABILITY" :class="biomeLinkClass" :show-source="false"
+    @mouseenter="onCardMouseEnter" @mouseleave="cardPreview.scheduleHide()">
 
     <!-- XP badge positioned relative to main description when character owns any improvements OR when improvements are expanded -->
     <template #description-badge>
@@ -49,7 +50,8 @@
     <!-- Overlay badges - Show XP badge at card level when character owns no improvements AND improvements are collapsed -->
     <!-- Also shown (hidden until card hover) for no-cost items when a character context is present -->
     <template #badges>
-      <BadgeDisplay v-if="(shouldShowBaseXpBadge || !!character) && !characterOwnsAnyImprovements && !showImprovements"
+      <BadgeDisplay
+        v-if="!collapsed && (shouldShowBaseXpBadge || !!character) && !characterOwnsAnyImprovements && !showImprovements"
         type="xp" :value="ability.xp ?? null" :is-owned="characterHasBaseAbility" :is-interactive="!!character"
         :hidden-by-default="!shouldShowBaseXpBadge && !characterHasBaseAbility" @toggle="handleBaseAbilityToggle" />
     </template>
@@ -59,6 +61,7 @@
 <script setup>
 import { computed } from 'vue'
 import { ChevronUpIcon, ChevronDownIcon } from '@heroicons/vue/24/outline'
+import { useCardPreview } from '@/composables/useCardPreview'
 import { useItemImprovements } from '@/composables/useItemImprovements'
 import { useActionTypesStore } from '@/stores/actionTypesStore'
 import { useCharactersStore } from '@/stores/charactersStore'
@@ -116,6 +119,14 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['edit', 'update', 'sendToChat', 'update:collapsed', 'update:showImprovements', 'update:showSuccesses', 'height-changed', 'roll-link'])
+
+const cardPreview = useCardPreview()
+
+function onCardMouseEnter(event) {
+  if (props.collapsed && props.collapsible) {
+    cardPreview.showAbilityPreview(props.ability, event.currentTarget)
+  }
+}
 
 // Item improvements composable
 const { toggleImprovement, getCharacterImprovements } = useItemImprovements('abilities')

--- a/packages/frontend/src/components/ui/cards/item/AbilityCard.vue
+++ b/packages/frontend/src/components/ui/cards/item/AbilityCard.vue
@@ -2,7 +2,7 @@
   <base-card :item="ability" :metaInfo="traitOrMp" :collapsed="collapsed" :editable="editable"
     @edit="$emit('edit', ability)" :collapsible="collapsible" @update:collapsed="$emit('update:collapsed', $event)"
     @roll-link="handleRollLinkWithBiome" :itemType="ItemType.ABILITY" :class="biomeLinkClass" :show-source="false"
-    @mouseenter="onCardMouseEnter" @mouseleave="cardPreview.scheduleHide()">
+    @mouseenter="onCardMouseEnter" @mouseleave="cardPreview.scheduleHide()" @mousedown="onCardMouseDown">
 
     <!-- XP badge positioned relative to main description when character owns any improvements OR when improvements are expanded -->
     <template #description-badge>
@@ -125,6 +125,12 @@ const cardPreview = useCardPreview()
 function onCardMouseEnter(event) {
   if (props.collapsed && props.collapsible) {
     cardPreview.showAbilityPreview(props.ability, event.currentTarget)
+  }
+}
+
+function onCardMouseDown() {
+  if (props.collapsible) {
+    cardPreview.startDragIntent({ expandCooldown: props.collapsed ? 800 : 0 })
   }
 }
 

--- a/packages/frontend/src/components/ui/cards/item/EquipmentCard.vue
+++ b/packages/frontend/src/components/ui/cards/item/EquipmentCard.vue
@@ -3,7 +3,7 @@
     :metaInfo="equipment.weight ? `${equipment.weight} ${equipment.weight === 1 ? 'lb' : 'lbs'}` : ''"
     :collapsed="collapsed" :editable="editable" :duplicatable="duplicatable" :collapsible="collapsible"
     :itemType="ItemType.EQUIPMENT" @edit="$emit('edit', equipment)" @duplicate="handleDuplicate"
-    @roll-link="$emit('roll-link', $event)">
+    @roll-link="$emit('roll-link', $event)" @mouseenter="onCardMouseEnter" @mouseleave="cardPreview.scheduleHide()">
 
     <!-- Description with categories, properties, dice, and successes -->
     <template #before-description>
@@ -92,7 +92,7 @@
     <!-- Also shown (hidden until card hover) for free items when a character context is present -->
     <template #badges>
       <BadgeDisplay
-        v-if="showKeepingBadge && (keepingCost !== null || !!character) && !characterOwnsAnyImprovements && !showImprovements"
+        v-if="!collapsed && showKeepingBadge && (keepingCost !== null || !!character) && !characterOwnsAnyImprovements && !showImprovements"
         type="keeping" :value="keepingCost" :is-owned="characterHasBaseEquipment" :is-interactive="!!character"
         :hidden-by-default="keepingCost === null && !characterHasBaseEquipment" @toggle="handleBaseEquipmentToggle" />
     </template>
@@ -103,6 +103,7 @@
 <script setup>
 import { onMounted, computed } from 'vue'
 import { ChevronUpIcon, ChevronDownIcon } from '@heroicons/vue/24/outline'
+import { useCardPreview } from '@/composables/useCardPreview'
 import { useEquipmentStore } from '@/stores/equipmentStore'
 import { useEquipmentTypesStore } from '@/stores/equipmentTypesStore'
 import { useEquipmentSubtypesStore } from '@/stores/equipmentSubtypesStore'
@@ -178,6 +179,14 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['edit', 'duplicate', 'update', 'height-changed', 'update:showImprovements', 'update:showSuccesses', 'roll-damage', 'roll-link'])
+
+const cardPreview = useCardPreview()
+
+function onCardMouseEnter(event) {
+  if (props.collapsed && props.collapsible) {
+    cardPreview.showEquipmentPreview(props.equipment, event.currentTarget)
+  }
+}
 
 // Stores
 const equipmentStore = useEquipmentStore()

--- a/packages/frontend/src/components/ui/cards/item/EquipmentCard.vue
+++ b/packages/frontend/src/components/ui/cards/item/EquipmentCard.vue
@@ -3,7 +3,7 @@
     :metaInfo="equipment.weight ? `${equipment.weight} ${equipment.weight === 1 ? 'lb' : 'lbs'}` : ''"
     :collapsed="collapsed" :editable="editable" :duplicatable="duplicatable" :collapsible="collapsible"
     :itemType="ItemType.EQUIPMENT" @edit="$emit('edit', equipment)" @duplicate="handleDuplicate"
-    @roll-link="$emit('roll-link', $event)" @mouseenter="onCardMouseEnter" @mouseleave="cardPreview.scheduleHide()">
+    @roll-link="$emit('roll-link', $event)" @mouseenter="onCardMouseEnter" @mouseleave="cardPreview.scheduleHide()" @mousedown="onCardMouseDown">
 
     <!-- Description with categories, properties, dice, and successes -->
     <template #before-description>
@@ -185,6 +185,12 @@ const cardPreview = useCardPreview()
 function onCardMouseEnter(event) {
   if (props.collapsed && props.collapsible) {
     cardPreview.showEquipmentPreview(props.equipment, event.currentTarget)
+  }
+}
+
+function onCardMouseDown() {
+  if (props.collapsible) {
+    cardPreview.startDragIntent({ expandCooldown: props.collapsed ? 800 : 0 })
   }
 }
 

--- a/packages/frontend/src/components/ui/cards/item/EquipmentCard.vue
+++ b/packages/frontend/src/components/ui/cards/item/EquipmentCard.vue
@@ -3,7 +3,8 @@
     :metaInfo="equipment.weight ? `${equipment.weight} ${equipment.weight === 1 ? 'lb' : 'lbs'}` : ''"
     :collapsed="collapsed" :editable="editable" :duplicatable="duplicatable" :collapsible="collapsible"
     :itemType="ItemType.EQUIPMENT" @edit="$emit('edit', equipment)" @duplicate="handleDuplicate"
-    @roll-link="$emit('roll-link', $event)" @mouseenter="onCardMouseEnter" @mouseleave="cardPreview.scheduleHide()" @mousedown="onCardMouseDown">
+    @roll-link="$emit('roll-link', $event)" @mouseenter="onCardMouseEnter" @mouseleave="cardPreview.scheduleHide()"
+    @mousedown="onCardMouseDown">
 
     <!-- Description with categories, properties, dice, and successes -->
     <template #before-description>

--- a/packages/frontend/src/components/ui/cards/preview/CardPreviewOverlay.vue
+++ b/packages/frontend/src/components/ui/cards/preview/CardPreviewOverlay.vue
@@ -1,0 +1,116 @@
+<template>
+    <Teleport to="body">
+        <Transition name="card-preview">
+            <div v-if="previewAbility || previewEquipment" ref="overlayEl" class="card-preview-overlay"
+                :class="{ 'placed-left': isOverlayOnLeftSide }" :style="overlayStyle" @mouseenter="cancelHide"
+                @mouseleave="scheduleHide">
+                <AbilityCard v-if="previewAbility" :ability="previewAbility" :collapsed="false" :collapsible="false"
+                    :editable="false" :show-xp-badge="true" :show-action-buttons="false"
+                    :show-improvement-toggle="false" :show-improvements="false" :show-successes="false" />
+                <EquipmentCard v-else-if="previewEquipment" :equipment="previewEquipment" :collapsed="false"
+                    :collapsible="false" :editable="false" :duplicatable="false" :show-keeping-badge="true"
+                    :show-improvement-toggle="false" :show-improvements="false" :engagement-success-options="[]"
+                    :enable-damage-roll="false" :show-successes="false" />
+            </div>
+        </Transition>
+    </Teleport>
+</template>
+
+<script setup>
+import { ref, computed, watch, nextTick } from 'vue'
+import AbilityCard from '@/components/ui/cards/item/AbilityCard.vue'
+import EquipmentCard from '@/components/ui/cards/item/EquipmentCard.vue'
+import { useCardPreview } from '@/composables/useCardPreview'
+
+const PREVIEW_WIDTH = 320
+const GAP = 12
+const VIEWPORT_MARGIN = 8
+
+const { previewAbility, previewEquipment, anchorRect, scheduleHide, cancelHide } = useCardPreview()
+
+const overlayEl = ref(null)
+// Tracks the rendered height of the overlay so we can clamp it to the viewport.
+const overlayHeight = ref(0)
+
+// Whenever the preview content changes, measure the overlay height on the next tick.
+watch(
+    [previewAbility, previewEquipment],
+    async () => {
+        if (!previewAbility.value && !previewEquipment.value) return
+        await nextTick()
+        overlayHeight.value = overlayEl.value?.offsetHeight ?? 0
+    }
+)
+
+const overlayStyle = computed(() => {
+    if (!anchorRect.value) return {}
+    const rect = anchorRect.value
+
+    // Prefer placing the preview to the right of the card.
+    // Fall back to the left when there is not enough viewport space.
+    let left = rect.right + GAP
+    if (isOverlayOnLeftSide.value) {
+        left = rect.left - PREVIEW_WIDTH - GAP
+    }
+    left = Math.max(VIEWPORT_MARGIN, left)
+
+    // Align the top of the preview with the top of the anchor card.
+    // If the preview would overflow the bottom of the viewport, shift it up
+    // just enough to keep it fully visible.
+    let top = rect.top
+    const height = overlayHeight.value
+    if (height > 0) {
+        const overflow = top + height - (window.innerHeight - VIEWPORT_MARGIN)
+        if (overflow > 0) top -= overflow
+    }
+    top = Math.max(VIEWPORT_MARGIN, top)
+
+    return {
+        top: top + 'px',
+        left: left + 'px',
+        width: PREVIEW_WIDTH + 'px',
+    }
+})
+
+// Tracks which side the overlay is placed on so the enter animation slides
+// in from the correct direction (toward the anchor card).
+const isOverlayOnLeftSide = computed(() => {
+    if (!anchorRect.value) return false
+    const rect = anchorRect.value
+    return rect.right + GAP + PREVIEW_WIDTH > window.innerWidth - VIEWPORT_MARGIN
+})
+</script>
+
+<style scoped>
+.card-preview-overlay {
+    position: fixed;
+    z-index: var(--z-tooltip);
+    max-height: 80vh;
+    overflow-y: auto;
+    overflow-x: hidden;
+    border-radius: var(--radius-10);
+    filter: drop-shadow(var(--shadow-elevation-xl));
+    pointer-events: auto;
+    /* Prevent scrollbars from causing layout shifts inside the preview */
+    scrollbar-width: thin;
+}
+
+/* Fade in from the side the card is on */
+.card-preview-enter-active,
+.card-preview-leave-active {
+    transition: opacity var(--transition-fast), transform var(--transition-fast);
+}
+
+/* Default: overlay is to the right — slide in from the left */
+.card-preview-enter-from,
+.card-preview-leave-to {
+    opacity: 0;
+    transform: scale(0.96) translateX(-6px);
+}
+
+/* Overlay is to the left — slide in from the right */
+.placed-left.card-preview-enter-from,
+.placed-left.card-preview-leave-to {
+    transform: scale(0.96) translateX(6px);
+}
+</style>

--- a/packages/frontend/src/components/ui/containers/CharacterSheetSection.vue
+++ b/packages/frontend/src/components/ui/containers/CharacterSheetSection.vue
@@ -42,7 +42,7 @@ const dynamicStyles = computed(() => {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    background-color: var(--color-bg-secondary);
+    background-color: var(--overlay-black-heavy);
     border-radius: var(--radius-5);
     padding: var(--space-lg);
     position: relative;

--- a/packages/frontend/src/components/ui/dropdowns/SortingDropdown.vue
+++ b/packages/frontend/src/components/ui/dropdowns/SortingDropdown.vue
@@ -3,7 +3,7 @@
         <label v-if="label" class="sorting-label">{{ label }}</label>
         <div class="sorting-dropdown">
             <select :value="modelValue" @input="$emit('update:modelValue', $event.target.value)" class="sort-select">
-                <option value="">{{ placeholder }}</option>
+                <option v-if="placeholder" value="">{{ placeholder }}</option>
 
                 <template v-if="isGrouped">
                     <optgroup v-for="(groupOptions, group) in options" :key="group" :label="group">
@@ -45,7 +45,7 @@ const props = defineProps({
     },
     placeholder: {
         type: String,
-        default: 'Sort by...'
+        default: ''
     }
 })
 
@@ -64,6 +64,7 @@ const isGrouped = computed(() => !Array.isArray(props.options))
 .sorting-label {
     font-family: var(--font-family-body);
     font-size: var(--font-size-13, 13px);
+    font-weight: var(--font-weight-normal);
     color: var(--color-text-secondary);
 }
 

--- a/packages/frontend/src/components/ui/layouts/ConceptsLayout.vue
+++ b/packages/frontend/src/components/ui/layouts/ConceptsLayout.vue
@@ -1,17 +1,19 @@
 <template>
   <div class="concepts-view">
-    <!-- Filter Controls -->
-    <FilterControls v-model:search-query="searchQuery" v-model:primary-filter="expansionFilter"
+
+    <!-- Filter Controls: hidden when concept detail is open -->
+    <FilterControls v-show="!showConceptDetail || modalComponent === 'CharacterSheetModal'"
+      v-model:search-query="searchQuery" v-model:primary-filter="expansionFilter"
       :search-placeholder="searchPlaceholder" :primary-filter-options="primaryFilterOptions"
       :primary-filter-label="primaryFilterLabel" :show-add-button="isAdmin" @create="createConcept" />
 
-    <!-- Selection Cards -->
-    <div class="concept-cards-container">
+    <!-- Selection Cards: hidden when concept detail is open -->
+    <div v-show="!showConceptDetail || modalComponent === 'CharacterSheetModal'" class="concept-cards-container">
       <ConceptCard v-for="concept in filteredConcepts" :key="concept.id" :concept="concept" :sources="sources"
         :expansions="expansionStore.items" @select="openConceptDetail" />
     </div>
 
-    <!-- Modal with Navigation Controls -->
+    <!-- Detail / Character Sheet with Navigation Controls -->
     <NavigationControls v-if="showConceptDetail" :has-previous="hasPreviousConcept" :has-next="hasNextConcept"
       @navigate="navigateConcept">
 
@@ -19,7 +21,7 @@
       <CharacterSheetModal v-if="modalComponent === 'CharacterSheetModal'" :key="`character-${props.selectedItem?.id}`"
         @close="closeConceptDetail" />
 
-      <!-- Concept Detail Modal -->
+      <!-- Concept Detail -->
       <ConceptDetail v-else :key="`concept-${props.selectedItem?.id}`" :editable="isAdmin"
         @close="closeConceptDetail" />
     </NavigationControls>

--- a/packages/frontend/src/components/ui/layouts/ConceptsLayout.vue
+++ b/packages/frontend/src/components/ui/layouts/ConceptsLayout.vue
@@ -2,13 +2,13 @@
   <div class="concepts-view">
 
     <!-- Filter Controls: hidden when concept detail is open -->
-    <FilterControls v-show="!showConceptDetail || modalComponent === 'CharacterSheetModal'"
-      v-model:search-query="searchQuery" v-model:primary-filter="expansionFilter"
-      :search-placeholder="searchPlaceholder" :primary-filter-options="primaryFilterOptions"
-      :primary-filter-label="primaryFilterLabel" :show-add-button="isAdmin" @create="createConcept" />
+    <FilterControls v-show="!showConceptDetail" v-model:search-query="searchQuery"
+      v-model:primary-filter="expansionFilter" :search-placeholder="searchPlaceholder"
+      :primary-filter-options="primaryFilterOptions" :primary-filter-label="primaryFilterLabel"
+      :show-add-button="isAdmin" @create="createConcept" />
 
     <!-- Selection Cards: hidden when concept detail is open -->
-    <div v-show="!showConceptDetail || modalComponent === 'CharacterSheetModal'" class="concept-cards-container">
+    <div v-show="!showConceptDetail" class="concept-cards-container">
       <ConceptCard v-for="concept in filteredConcepts" :key="concept.id" :concept="concept" :sources="sources"
         :expansions="expansionStore.items" @select="openConceptDetail" />
     </div>

--- a/packages/frontend/src/components/ui/layouts/GroupedThreeColumnLayout.vue
+++ b/packages/frontend/src/components/ui/layouts/GroupedThreeColumnLayout.vue
@@ -1,0 +1,220 @@
+<template>
+    <div class="grouped-three-column-layout">
+        <div v-for="group in groupedItems" :key="group.id ?? group.name" class="group-section">
+            <h3 class="group-header" @click="toggleGroup(group.id ?? group.name)">
+                <ChevronRightIcon v-if="isGroupCollapsed(group)" class="chevron-icon" />
+                <ChevronDownIcon v-else class="chevron-icon" />
+
+                <!-- Inline rename for custom groups -->
+                <input v-if="customGroupMode && editingGroupId === (group.id ?? group.name) && !group.isUngrouped"
+                    v-model="editingGroupName" class="group-name-input" @blur="commitRename(group)"
+                    @keydown.enter="commitRename(group)" @keydown.escape="cancelRename" @click.stop
+                    :ref="el => { if (el) renameInput = el }" />
+
+                <span v-else class="group-name"
+                    @dblclick.stop="customGroupMode && !group.isUngrouped ? startRename(group) : null">
+                    {{ group.name }}
+                    <span class="group-count">({{ group.items.length }})</span>
+                </span>
+
+                <!-- Custom-group controls (rename / delete) -->
+                <template v-if="customGroupMode && !group.isUngrouped && editingGroupId !== (group.id ?? group.name)">
+                    <button class="group-action-btn" title="Rename group" aria-label="Rename group"
+                        @click.stop="startRename(group)">
+                        <PencilIcon class="group-action-icon" />
+                    </button>
+                    <button class="group-action-btn group-action-btn--danger" title="Delete group"
+                        aria-label="Delete group" @click.stop="emit('delete-group', group.id)">
+                        <XMarkIcon class="group-action-icon" />
+                    </button>
+                </template>
+            </h3>
+
+            <div v-if="!isGroupCollapsed(group)" class="group-content">
+                <!-- In custom mode all groups share a single SortableJS group so cards can cross boundaries -->
+                <ThreeColumnLayout :items="strippedGroupItems.get(group.id ?? group.name)" :is-draggable="draggable"
+                    :group-id="customGroupMode ? customGroupId : String(group.id ?? group.name)"
+                    @reorder="(newItems) => emit('reorder-group', group.id, newItems)">
+                    <template #default="slotProps">
+                        <slot v-bind="slotProps" />
+                    </template>
+                </ThreeColumnLayout>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script setup>
+import { ref, computed, nextTick } from 'vue'
+import { ChevronDownIcon, ChevronRightIcon, PencilIcon, XMarkIcon } from '@heroicons/vue/24/outline'
+import ThreeColumnLayout from './ThreeColumnLayout.vue'
+
+const props = defineProps({
+    groupedItems: {
+        type: Array,
+        required: true
+    },
+    draggable: {
+        type: Boolean,
+        default: false
+    },
+    // When true, renders rename/delete controls and enables cross-group drag
+    customGroupMode: {
+        type: Boolean,
+        default: false
+    },
+    // Scopes cross-group drag to this table only; must be unique per table
+    customGroupId: {
+        type: String,
+        default: 'custom-group'
+    }
+})
+
+const emit = defineEmits(['reorder-group', 'rename-group', 'delete-group'])
+
+const collapsedGroupKeys = ref(new Set())
+const editingGroupId = ref(null)
+const editingGroupName = ref('')
+const renameInput = ref(null)
+
+function isGroupCollapsed(group) {
+    return collapsedGroupKeys.value.has(group.id ?? group.name)
+}
+
+function toggleGroup(key) {
+    const next = new Set(collapsedGroupKeys.value)
+    if (next.has(key)) next.delete(key)
+    else next.add(key)
+    collapsedGroupKeys.value = next
+}
+
+function startRename(group) {
+    editingGroupId.value = group.id ?? group.name
+    editingGroupName.value = group.name
+    nextTick(() => renameInput.value?.focus())
+}
+
+function commitRename(group) {
+    const trimmed = editingGroupName.value.trim()
+    if (trimmed && trimmed !== group.name) {
+        emit('rename-group', group.id, trimmed)
+    }
+    cancelRename()
+}
+
+function cancelRename() {
+    editingGroupId.value = null
+    editingGroupName.value = ''
+}
+
+// Precompute stripped items per group to avoid creating new arrays on every render.
+// ThreeColumnLayout distributes items by position (round-robin) within each group
+// rather than using the global column assignment from the parent.
+const strippedGroupItems = computed(() =>
+    new Map(
+        props.groupedItems.map(group => [
+            group.id ?? group.name,
+            group.items.map(({ columnIndex: _ignored, ...rest }) => rest)
+        ])
+    )
+)
+</script>
+
+<style scoped>
+.grouped-three-column-layout {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2xl);
+}
+
+.group-section {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-md);
+    padding-bottom: var(--space-lg);
+}
+
+.group-header {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    font-size: var(--font-size-20);
+    font-weight: var(--font-weight-bold);
+    color: var(--color-primary);
+    margin: 0;
+    padding-bottom: var(--space-sm);
+    border-bottom: 2px solid var(--color-border-secondary);
+    user-select: none;
+    cursor: pointer;
+    text-align: left;
+    transition: var(--transition-color);
+}
+
+.group-header:hover {
+    color: var(--color-primary-hover);
+}
+
+.chevron-icon {
+    width: 20px;
+    height: 20px;
+    flex-shrink: 0;
+}
+
+.group-name {
+    flex: 1;
+}
+
+.group-count {
+    font-size: var(--font-size-16);
+    font-weight: var(--font-weight-normal);
+    color: var(--color-text-secondary);
+}
+
+.group-name-input {
+    flex: 1;
+    background: var(--color-bg-primary);
+    border: 1px solid var(--color-primary);
+    border-radius: var(--radius-5);
+    color: var(--color-text-primary);
+    font-family: inherit;
+    font-size: var(--font-size-20);
+    font-weight: var(--font-weight-bold);
+    padding: 0 var(--space-xs);
+    outline: none;
+}
+
+.group-action-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: none;
+    border: none;
+    padding: var(--space-xs);
+    border-radius: var(--radius-5);
+    color: var(--color-text-secondary);
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity var(--transition-fast), color var(--transition-fast);
+}
+
+.group-header:hover .group-action-btn {
+    opacity: 1;
+}
+
+.group-action-btn:hover {
+    color: var(--color-text-primary);
+}
+
+.group-action-btn--danger:hover {
+    color: var(--color-danger);
+}
+
+.group-action-icon {
+    width: 16px;
+    height: 16px;
+}
+
+.group-content {
+    width: 100%;
+}
+</style>

--- a/packages/frontend/src/components/ui/layouts/MasonryGrid.vue
+++ b/packages/frontend/src/components/ui/layouts/MasonryGrid.vue
@@ -62,7 +62,7 @@ function initMasonry() {
   container.style.display = 'grid'
   container.style.gridAutoRows = `${props.rowHeight}px`
   container.style.gap = `${props.gap}px`
-  container.style.justifyContent = 'center'
+  container.style.justifyContent = 'start'
 
   nextTick(() => {
     updateLayoutImmediate()

--- a/packages/frontend/src/components/ui/layouts/ThreeColumnLayout.vue
+++ b/packages/frontend/src/components/ui/layouts/ThreeColumnLayout.vue
@@ -1,0 +1,195 @@
+<template>
+    <div class="three-column-layout" :class="{ 'is-dragging': isDragging }">
+        <div v-for="(_, colIndex) in columns" :key="colIndex" class="column">
+            <draggable v-model="columns[colIndex]" :group="{ name: groupId, pull: true, put: true }" item-key="id"
+                :disabled="!isDraggable" @start="onDragStart" @end="onDragEnd" @add="onDragEnd" @remove="onDragRemove"
+                class="column-drop-zone" :class="{ 'drag-enabled': isDraggable }">
+                <template #item="{ element }">
+                    <div class="column-item">
+                        <slot :item="element" />
+                    </div>
+                </template>
+            </draggable>
+        </div>
+    </div>
+</template>
+
+<script setup>
+import { ref, watch } from 'vue'
+import draggable from 'vuedraggable'
+import { useCardPreview } from '@/composables/useCardPreview'
+
+const props = defineProps({
+    items: {
+        type: Array,
+        required: true
+    },
+    isDraggable: {
+        type: Boolean,
+        default: false
+    },
+    groupId: {
+        type: String,
+        default: 'items'
+    }
+})
+
+const emit = defineEmits(['reorder'])
+
+const { setDragging } = useCardPreview()
+
+// Three writable column arrays for vuedraggable
+const columns = ref([[], [], []])
+
+const isDragging = ref(false)
+
+// Fully rebuild columns from items array using columnIndex (or idx % 3 fallback).
+function distributeItems(items, isDraggable) {
+    const cols = [[], [], []]
+    items.forEach((item, idx) => {
+        const colIdx = isDraggable && typeof item.columnIndex === 'number'
+            ? item.columnIndex % 3
+            : idx % 3
+        cols[colIdx].push(item)
+    })
+    columns.value = cols
+}
+
+// Update item data within existing column slots without reshuffling.
+// Called after a drag save is echoed back through props — item IDs and column
+// positions are already correct, but data properties (e.g. collapsed) may
+// have been updated by the save round-trip.
+function refreshItemData(items) {
+    const itemMap = new Map(items.map(i => [i.id, i]))
+    for (let c = 0; c < 3; c++) {
+        columns.value[c] = columns.value[c].map(colItem => itemMap.get(colItem.id) ?? colItem)
+    }
+}
+
+// When drag mode toggles, always redistribute from scratch.
+watch(
+    () => props.isDraggable,
+    (val) => {
+        if (!isDragging.value) {
+            distributeItems(props.items, val)
+        }
+    }
+)
+
+// When items change:
+//  - If still dragging → ignore (vuedraggable owns the state)
+//  - If items were added or removed, or we are in sort mode → full redistribute
+//  - Otherwise (same IDs, drag mode) → just refresh item data in place so we
+//    don't reshuffle a drag result that was just saved to the parent
+watch(
+    () => props.items,
+    (items) => {
+        if (isDragging.value) return
+
+        const currentIds = new Set(columns.value.flat().map(i => i.id))
+        const newIds = new Set(items.map(i => i.id))
+        const structureChanged =
+            currentIds.size !== newIds.size ||
+            [...newIds].some(id => !currentIds.has(id)) ||
+            [...currentIds].some(id => !newIds.has(id))
+
+        if (structureChanged || !props.isDraggable) {
+            distributeItems(items, props.isDraggable)
+        } else {
+            refreshItemData(items)
+        }
+    },
+    { immediate: true }
+)
+
+// Captured at drag start to detect no-op drops in onDragEnd.
+let preDragSnapshot = null
+// Set when an item leaves this layout (cross-group drag). In that case @add on
+// the target layout handles persistence, so @end on the source should not emit.
+let itemWasRemoved = false
+
+function onDragStart() {
+    isDragging.value = true
+    setDragging(true)
+    preDragSnapshot = columns.value.flatMap((col, c) => col.map(item => `${item.id}:${c}`))
+}
+
+function onDragRemove() {
+    itemWasRemoved = true
+}
+
+function onDragEnd() {
+    isDragging.value = false
+    setDragging(false)
+    if (itemWasRemoved) {
+        // The receiving layout's @add already fired onDragEnd and will emit the
+        // updated items — suppress the duplicate emit from the source layout.
+        itemWasRemoved = false
+        return
+    }
+    // Emit a flat array: all col-0 items first, then col-1, then col-2.
+    // Within-column order is preserved exactly as vuedraggable left it.
+    // columnIndex on each emitted item reflects the column it now belongs to.
+    const newItems = []
+    for (let c = 0; c < 3; c++) {
+        for (const item of columns.value[c]) {
+            newItems.push({ ...item, columnIndex: c })
+        }
+    }
+    // Skip the emit if nothing actually moved (dropped back in the same position)
+    const newSnapshot = newItems.map(i => `${i.id}:${i.columnIndex}`)
+    if (preDragSnapshot && preDragSnapshot.join(',') === newSnapshot.join(',')) return
+    emit('reorder', newItems)
+}
+</script>
+
+<style scoped>
+.three-column-layout {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: var(--space-lg);
+    align-items: start;
+}
+
+.column {
+    display: flex;
+    flex-direction: column;
+}
+
+.column-drop-zone {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-md);
+    min-height: 48px;
+}
+
+.column-drop-zone.drag-enabled {
+    border-radius: var(--radius-5);
+    transition: background-color var(--transition-fast);
+}
+
+/* Empty column drop target — only visible when a drag is actively in progress */
+.three-column-layout.is-dragging .column-drop-zone:empty {
+    background: var(--color-bg-tertiary);
+    border: 1px dashed var(--color-border-secondary);
+    min-height: 60px;
+}
+
+/* Always leave a droppable zone below the last card in every column while dragging */
+.three-column-layout.is-dragging .column-drop-zone {
+    padding-bottom: 60px;
+}
+
+.column-item {
+    position: relative;
+}
+
+:deep(.sortable-ghost) {
+    opacity: 0.35;
+    border-radius: var(--radius-10);
+}
+
+:deep(.sortable-chosen) {
+    cursor: grabbing;
+}
+</style>

--- a/packages/frontend/src/composables/useCardPreview.js
+++ b/packages/frontend/src/composables/useCardPreview.js
@@ -14,6 +14,10 @@ const isDragging = ref(false)
 let hideTimer = null
 let showTimer = null
 
+// Tracks whether SortableJS has confirmed a drag started after a mousedown.
+let officialDragActive = false
+let pendingMouseUpListener = null
+
 export function useCardPreview() {
   function showAbilityPreview(ability, element) {
     if (isDragging.value) return
@@ -57,6 +61,7 @@ export function useCardPreview() {
   }
 
   function setDragging(value) {
+    officialDragActive = value
     isDragging.value = value
     if (value) {
       clearTimeout(showTimer)
@@ -64,7 +69,42 @@ export function useCardPreview() {
       previewAbility.value = null
       previewEquipment.value = null
       anchorRect.value = null
+    } else {
+      if (pendingMouseUpListener) {
+        document.removeEventListener('mouseup', pendingMouseUpListener, true)
+        pendingMouseUpListener = null
+      }
     }
+  }
+
+  // Called on mousedown on a card. Immediately dismisses any visible preview
+  // and suppresses new ones. If the mouseup arrives without a SortableJS drag
+  // having started, previews are re-enabled — after expandCooldown ms when the
+  // click is expanding a collapsed card, immediately otherwise.
+  function startDragIntent({ expandCooldown = 0 } = {}) {
+    if (pendingMouseUpListener) {
+      document.removeEventListener('mouseup', pendingMouseUpListener, true)
+      pendingMouseUpListener = null
+    }
+    clearTimeout(showTimer)
+    clearTimeout(hideTimer)
+    previewAbility.value = null
+    previewEquipment.value = null
+    anchorRect.value = null
+    isDragging.value = true
+    officialDragActive = false
+
+    pendingMouseUpListener = () => {
+      pendingMouseUpListener = null
+      if (!officialDragActive) {
+        if (expandCooldown > 0) {
+          setTimeout(() => { isDragging.value = false }, expandCooldown)
+        } else {
+          isDragging.value = false
+        }
+      }
+    }
+    document.addEventListener('mouseup', pendingMouseUpListener, { once: true, capture: true })
   }
 
   return {
@@ -77,5 +117,6 @@ export function useCardPreview() {
     scheduleHide,
     cancelHide,
     setDragging,
+    startDragIntent,
   }
 }

--- a/packages/frontend/src/composables/useCardPreview.js
+++ b/packages/frontend/src/composables/useCardPreview.js
@@ -1,0 +1,81 @@
+import { ref } from 'vue'
+
+const SHOW_DELAY_MS = 400
+const HIDE_DELAY_MS = 120
+
+// Module-level singleton so any card and the overlay share the same state.
+const previewAbility = ref(null)
+const previewEquipment = ref(null)
+// DOMRect of the collapsed card that triggered the preview (viewport-relative).
+const anchorRect = ref(null)
+// Suppresses all previews while a drag is in progress.
+const isDragging = ref(false)
+
+let hideTimer = null
+let showTimer = null
+
+export function useCardPreview() {
+  function showAbilityPreview(ability, element) {
+    if (isDragging.value) return
+    clearTimeout(hideTimer)
+    clearTimeout(showTimer)
+    // Delay showing so a quick mousedown-drag doesn't trigger the preview.
+    showTimer = setTimeout(() => {
+      if (isDragging.value) return
+      previewEquipment.value = null
+      previewAbility.value = ability
+      anchorRect.value = element.getBoundingClientRect()
+    }, SHOW_DELAY_MS)
+  }
+
+  function showEquipmentPreview(equipment, element) {
+    if (isDragging.value) return
+    clearTimeout(hideTimer)
+    clearTimeout(showTimer)
+    showTimer = setTimeout(() => {
+      if (isDragging.value) return
+      previewAbility.value = null
+      previewEquipment.value = equipment
+      anchorRect.value = element.getBoundingClientRect()
+    }, SHOW_DELAY_MS)
+  }
+
+  // Short delay so moving the mouse from the collapsed card into the preview
+  // pane does not cause the preview to flicker out.
+  function scheduleHide() {
+    clearTimeout(showTimer)
+    clearTimeout(hideTimer)
+    hideTimer = setTimeout(() => {
+      previewAbility.value = null
+      previewEquipment.value = null
+      anchorRect.value = null
+    }, HIDE_DELAY_MS)
+  }
+
+  function cancelHide() {
+    clearTimeout(hideTimer)
+  }
+
+  function setDragging(value) {
+    isDragging.value = value
+    if (value) {
+      clearTimeout(showTimer)
+      clearTimeout(hideTimer)
+      previewAbility.value = null
+      previewEquipment.value = null
+      anchorRect.value = null
+    }
+  }
+
+  return {
+    previewAbility,
+    previewEquipment,
+    anchorRect,
+    isDragging,
+    showAbilityPreview,
+    showEquipmentPreview,
+    scheduleHide,
+    cancelHide,
+    setDragging,
+  }
+}

--- a/packages/frontend/src/composables/useCustomGroupManagement.js
+++ b/packages/frontend/src/composables/useCustomGroupManagement.js
@@ -1,0 +1,94 @@
+import { v4 as uuidv4 } from 'uuid'
+
+// Shared reorder / create / rename / delete logic for custom-grouped item tables (abilities, equipment).
+export function useCustomGroupManagement(character, itemsKey, customGroupsKey, groupingOption) {
+  // Persist a drag-reordered flat array back to the character.
+  // newItems have updated columnIndex values set by ThreeColumnLayout.
+  function handleFlatReorder(newItems) {
+    if (!character.value?.[itemsKey]) return
+    const current = character.value[itemsKey]
+    character.value[itemsKey] = newItems
+      .map(item => {
+        const original = current.find(a => a.id === item.id)
+        return original ? { ...original, columnIndex: item.columnIndex } : null
+      })
+      .filter(Boolean)
+  }
+
+  // Persist a within-group drag reorder back to the character.
+  // Reordered items are placed at the same flat-array slots their group previously occupied.
+  function handleGroupReorder(_groupId, reorderedGroupItems) {
+    if (!character.value?.[itemsKey]) return
+    const reorderedIds = reorderedGroupItems.map(item => item.id)
+    const groupIdSet = new Set(reorderedIds)
+    const current = character.value[itemsKey]
+    const groupFlatIndices = current
+      .map((a, i) => (groupIdSet.has(a.id) ? i : -1))
+      .filter(i => i !== -1)
+    if (groupFlatIndices.length === 0) return
+    const newItems = [...current]
+    groupFlatIndices.forEach((flatIdx, orderIdx) => {
+      const entry = current.find(a => a.id === reorderedIds[orderIdx])
+      if (entry) newItems[flatIdx] = entry
+    })
+    character.value[itemsKey] = newItems
+  }
+
+  // Custom grouping: cross-group reorder. A card was dropped into a different group,
+  // so update its customGroupId and re-merge all group arrays back into the flat list.
+  function handleCustomGroupReorder(groupId, reorderedGroupItems) {
+    if (!character.value?.[itemsKey]) return
+    const updatedIds = new Set(reorderedGroupItems.map(i => i.id))
+    const current = [...character.value[itemsKey]]
+    const remaining = current.filter(a => !updatedIds.has(a.id))
+    const reinserted = reorderedGroupItems
+      .map(item => {
+        const original = current.find(a => a.id === item.id)
+        return original ? { ...original, customGroupId: groupId === '__ungrouped__' ? null : groupId } : null
+      })
+      .filter(Boolean)
+    character.value[itemsKey] = [...remaining, ...reinserted]
+  }
+
+  // Named dispatcher so Vue passes all event args correctly.
+  function onGroupReorder(groupId, items) {
+    if (groupingOption.value === 'custom') {
+      handleCustomGroupReorder(groupId, items)
+    } else {
+      handleGroupReorder(groupId, items)
+    }
+  }
+
+  function createGroup() {
+    if (!character.value) return
+    const newGroup = { id: uuidv4(), name: 'New Group' }
+    character.value[customGroupsKey] = [
+      ...(character.value[customGroupsKey] ?? []),
+      newGroup
+    ]
+  }
+
+  function renameGroup(groupId, newName) {
+    if (!character.value?.[customGroupsKey]) return
+    const idx = character.value[customGroupsKey].findIndex(g => g.id === groupId)
+    if (idx !== -1) {
+      character.value[customGroupsKey][idx] = {
+        ...character.value[customGroupsKey][idx],
+        name: newName
+      }
+    }
+  }
+
+  function deleteGroup(groupId) {
+    if (!character.value) return
+    // Un-assign items from the deleted group before removing the group definition
+    character.value[itemsKey] = (character.value[itemsKey] ?? []).map(a =>
+      a.customGroupId === groupId ? { ...a, customGroupId: null } : a
+    )
+    character.value[customGroupsKey] = (character.value[customGroupsKey] ?? []).filter(
+      g => g.id !== groupId
+    )
+  }
+
+  return { handleFlatReorder, onGroupReorder, createGroup, renameGroup, deleteGroup }
+}

--- a/packages/frontend/src/composables/useItemGrouping.js
+++ b/packages/frontend/src/composables/useItemGrouping.js
@@ -2,8 +2,10 @@ import { computed } from 'vue'
 import { getManaCostColors } from '@shared/utils/calculateManaCost'
 import { ManaColor, MANA_COLOR_ORDER } from '@shared/constants/manaColors'
 
-// Accepts groupingMode as a string ref ('source', 'mana-color', '') or a boolean ref (treated as 'source').
-export function useItemGrouping(items, groupingMode, sourcesStore) {
+// Accepts groupingMode as a string ref ('source', 'mana-color', 'custom', '') or a boolean ref (treated as 'source').
+// When mode is 'custom', customGroups must be a ref to an array of { id, name } objects and
+// items must carry a customGroupId property to assign them to a group.
+export function useItemGrouping(items, groupingMode, sourcesStore, customGroups) {
   
   const resolvedMode = computed(() => {
     const mode = groupingMode.value
@@ -16,6 +18,7 @@ export function useItemGrouping(items, groupingMode, sourcesStore) {
   const groupedItems = computed(() => {
     if (!hasGrouping.value) return []
     if (resolvedMode.value === 'mana-color') return groupByManaColor(items.value)
+    if (resolvedMode.value === 'custom') return groupByCustom(items.value, customGroups?.value ?? [])
     return groupBySource(items.value, sourcesStore)
   })
 
@@ -103,5 +106,44 @@ function groupByManaColor(items) {
     const bi = MANA_COLOR_GROUP_ORDER.indexOf(b.id)
     return (ai === -1 ? 999 : ai) - (bi === -1 ? 999 : bi)
   })
+}
+
+// Groups items by their customGroupId, respecting the user-defined group order.
+// Items with no customGroupId (or an unrecognised one) fall into an "Ungrouped" section at the end.
+function groupByCustom(items, customGroups) {
+  const groupMap = new Map()
+
+  // Seed map with defined groups in their defined order (preserving empty groups)
+  customGroups.forEach(g => {
+    groupMap.set(g.id, {
+      id: g.id,
+      name: g.name,
+      collapsed: false,
+      items: [],
+      isCustom: true
+    })
+  })
+
+  const ungrouped = {
+    id: '__ungrouped__',
+    name: 'Ungrouped',
+    collapsed: false,
+    items: [],
+    isUngrouped: true
+  }
+
+  items.forEach(item => {
+    const gid = item.customGroupId
+    if (gid && groupMap.has(gid)) {
+      groupMap.get(gid).items.push(item)
+    } else {
+      ungrouped.items.push(item)
+    }
+  })
+
+  const result = [...groupMap.values()]
+  // Always append the Ungrouped section (even if empty, so it acts as a drop target)
+  result.push(ungrouped)
+  return result
 }
 

--- a/packages/frontend/src/config/conceptLayoutConfig.js
+++ b/packages/frontend/src/config/conceptLayoutConfig.js
@@ -13,6 +13,7 @@ export const CONCEPT_LAYOUT_CONFIGS = {
     showPlaylist: false,
     showAbilities: true,
     showEquipment: true,
+    showPhysiology: false,
   },
   [ConceptType.CULTURE]: {
     showNovizio: false,
@@ -24,6 +25,7 @@ export const CONCEPT_LAYOUT_CONFIGS = {
     showPlaylist: true,
     showAbilities: true,
     showEquipment: true,
+    showPhysiology: false,
   },
   [ConceptType.ANCESTRY]: {
     showNovizio: false,
@@ -36,6 +38,7 @@ export const CONCEPT_LAYOUT_CONFIGS = {
     showPlaylist: false,
     showAbilities: true,
     showEquipment: false,
+    showPhysiology: true,
   },
   [ConceptType.WORLD_ELEMENT]: {
     showNovizio: false,
@@ -47,6 +50,7 @@ export const CONCEPT_LAYOUT_CONFIGS = {
     showPlaylist: true,
     showAbilities: true,
     showEquipment: true,
+    showPhysiology: false,
   },
 }
 
@@ -62,4 +66,5 @@ export const DEFAULT_LAYOUT_CONFIG = {
   showPlaylist: true,
   showAbilities: true,
   showEquipment: true,
+  showPhysiology: false,
 }

--- a/packages/frontend/src/pages/EquipmentPage.vue
+++ b/packages/frontend/src/pages/EquipmentPage.vue
@@ -56,10 +56,7 @@
 
     <!-- Modals slot -->
     <template #modals>
-      <EditEquipmentModal v-if="showEditEquipmentModal" :equipment="equipmentToEdit" :all-equipment="allEquipment"
-        :keeping-options="keeping" :sources="sources" :equipment-types="equipmentTypes"
-        :equipment-subtypes="equipmentSubtypes" :equipment-grades="equipmentGrades" :equipment-ranges="equipmentRanges"
-        :engagement-success-options="engagementSuccessOptions" @update="saveEditedEquipment"
+      <EditEquipmentModal v-if="showEditEquipmentModal" :equipment="equipmentToEdit" @update="saveEditedEquipment"
         @close="closeEditEquipmentModal" @delete="deleteEquipment(equipmentToEdit)" />
     </template>
   </ItemCardsLayout>
@@ -73,6 +70,7 @@ import { useEquipmentSubtypesStore } from '@/stores/equipmentSubtypesStore'
 import { useEquipmentGradesStore } from '@/stores/equipmentGradesStore'
 import { useEquipmentRangesStore } from '@/stores/equipmentRangesStore'
 import { useKeepingStore } from '@/stores/keepingStore'
+import { useEngagementSuccessesStore } from '@/stores/engagementSuccessesStore'
 import { useAuthStore } from '@/stores/authStore'
 import { useSourcesStore } from '@/stores/sourcesStore'
 import { useCharactersStore } from '@/stores/charactersStore'
@@ -82,7 +80,6 @@ import { useInfiniteScrollObserver } from '@/composables/useInfiniteScrollObserv
 import { useFilterPersistence } from '@/composables/useFilterPersistence'
 import { sortItems } from '@/utils/sortItems'
 import { EQUIPMENT_SORT_OPTIONS, filterAdminSortOptions } from '@/constants/sortOptions'
-import EngagementSuccessService from '@/services/entities/engagementSuccessService'
 import EquipmentCard from '@/components/ui/cards/item/EquipmentCard.vue'
 import EditEquipmentModal from '@/components/editModals/EditEquipmentModal.vue'
 import ItemCardsLayout from '@/components/ui/layouts/ItemCardsLayout.vue'
@@ -94,6 +91,7 @@ const equipmentSubtypesStore = useEquipmentSubtypesStore()
 const equipmentGradesStore = useEquipmentGradesStore()
 const equipmentRangesStore = useEquipmentRangesStore()
 const keepingStore = useKeepingStore()
+const engagementSuccessesStore = useEngagementSuccessesStore()
 const authStore = useAuthStore()
 const sourcesStore = useSourcesStore()
 const charactersStore = useCharactersStore()
@@ -117,7 +115,7 @@ const typeFilter = ref('')
 const subtypeFilter = ref('')
 const gradeFilter = ref('')
 const showTemplates = ref(false)
-const engagementSuccessOptions = ref([])
+const engagementSuccessOptions = computed(() => engagementSuccessesStore.items)
 const isLoadingMore = ref(false)
 const improvementVisibility = ref(new Map())
 const successesVisibility = ref(new Map())
@@ -274,7 +272,7 @@ const handleDuplicateEquipment = async () => {
 
 const fetchEngagementSuccessOptions = async () => {
   try {
-    engagementSuccessOptions.value = await EngagementSuccessService.getAll()
+    await engagementSuccessesStore.fetch()
   } catch (error) {
     console.error('Error fetching engagement success options:', error)
   }
@@ -328,11 +326,7 @@ const layoutProps = computed(() => ({
 }))
 
 const equipmentTypes = computed(() => equipmentTypesStore.items)
-const equipmentSubtypes = computed(() => equipmentSubtypesStore.items)
 const equipmentGrades = computed(() => equipmentGradesStore.items)
-const equipmentRanges = computed(() => equipmentRangesStore.items)
-const keeping = computed(() => keepingStore.keeping)
-const allEquipment = computed(() => equipmentStore.equipment)
 </script>
 
 <style scoped>

--- a/packages/frontend/src/pages/VirtualTabletopPage.vue
+++ b/packages/frontend/src/pages/VirtualTabletopPage.vue
@@ -61,11 +61,9 @@
         <EditAbilityModal v-if="showEditAbilityModal" :ability="abilityToEdit" @update="handleAbilityModalUpdate"
             @delete="handleAbilityModalDelete" @close="closeEditAbilityModal" />
 
-        <EditEquipmentModal v-if="showEditEquipmentModal" :equipment="equipmentToEdit" :all-equipment="allEquipment"
-            :keeping-options="keepingOptions" :equipment-types="equipmentTypes" :equipment-subtypes="equipmentSubtypes"
-            :equipment-grades="equipmentGrades" :equipment-ranges="equipmentRanges"
-            :engagement-success-options="engagementSuccessOptions" @update="handleEquipmentModalUpdate"
-            @delete="handleEquipmentModalDelete" @close="closeEditEquipmentModal" />
+        <EditEquipmentModal v-if="showEditEquipmentModal" :equipment="equipmentToEdit"
+            @update="handleEquipmentModalUpdate" @delete="handleEquipmentModalDelete"
+            @close="closeEditEquipmentModal" />
 
         <!-- Bottom Toolbar -->
         <TabletopToolbar :show-picker="showPicker" :scale="transform.scale" :snap-to-grid="snapToGrid"
@@ -169,14 +167,8 @@ const selectionRectangleStyle = computed(() => {
 // Loading
 const isLoading = ref(true)
 
-// Store-derived data for modals
+// Store-derived data shared with canvas components
 const engagementSuccessOptions = computed(() => engagementSuccessesStore.items)
-const allEquipment = computed(() => equipmentStore.equipment)
-const keepingOptions = computed(() => keepingStore.items)
-const equipmentTypes = computed(() => equipmentTypesStore.items)
-const equipmentSubtypes = computed(() => equipmentSubtypesStore.items)
-const equipmentGrades = computed(() => equipmentGradesStore.items)
-const equipmentRanges = computed(() => equipmentRangesStore.items)
 
 // Edit modals – Abilities
 const showEditAbilityModal = ref(false)

--- a/packages/frontend/src/router/router.js
+++ b/packages/frontend/src/router/router.js
@@ -18,30 +18,17 @@ import VirtualTabletopPage from '@/pages/VirtualTabletopPage.vue'
 
 const routes = [
   { path: '/', component: TitlePage },
-  { path: '/rules', name: 'Rules', component: RulesPage },
-  { path: '/rules/:id', component: RulesPage },
-  { path: '/ancestries', component: AncestriesPage },
-  { path: '/ancestries/:id', component: AncestriesPage },
-  { path: '/cultures', component: CulturesPage },
-  { path: '/cultures/:id', component: CulturesPage },
-  { path: '/mestieri', component: MestieriPage },
-  { path: '/mestieri/:id', component: MestieriPage },
-  { path: '/world-elements', component: WorldElementsPage },
-  { path: '/world-elements/:id', component: WorldElementsPage },
+  { path: '/rules/:id?', name: 'Rules', component: RulesPage },
+  { path: '/ancestries/:id?', component: AncestriesPage },
+  { path: '/cultures/:id?', component: CulturesPage },
+  { path: '/mestieri/:id?', component: MestieriPage },
+  { path: '/world-elements/:id?', component: WorldElementsPage },
   { 
-    path: '/characters', 
+    path: '/characters/:id?', 
     component: CharactersPage
   },
   { 
-    path: '/characters/:id', 
-    component: CharactersPage
-  },
-  { 
-    path: '/bestiary', 
-    component: BestiaryPage
-  },
-  { 
-    path: '/bestiary/:id', 
+    path: '/bestiary/:id?', 
     component: BestiaryPage
   },
   { 

--- a/packages/frontend/src/styles/design-tokens.css
+++ b/packages/frontend/src/styles/design-tokens.css
@@ -96,6 +96,7 @@
   /* Elevation shadows */
   --shadow-elevation-sm: 0 2px 8px var(--color-black);          /* Small elevation */
   --shadow-elevation-lg: 0 2px 12px var(--color-black);         /* Large elevation */
+  --shadow-elevation-xl: 0 8px 24px rgba(0, 0, 0, 0.7);         /* Extra-large elevation (floating overlays) */
 
   /* Glow effects */
   --shadow-glow-sm: 0 0 5px var(--color-white);                 /* Small glow */

--- a/shared/types/entities/character.js
+++ b/shared/types/entities/character.js
@@ -46,6 +46,8 @@ import { createBaseEntity } from './gameEntity.js'
  * @property {number} index - Display order index
  * @property {boolean} collapsed - Whether item display is collapsed in UI
  * @property {boolean} artExpanded - Whether art view is expanded in UI
+ * @property {number} [columnIndex] - Column index (0-2) in the three-column layout
+ * @property {string|null} [customGroupId] - ID of the custom group this item belongs to
  */
 
 /**
@@ -55,6 +57,8 @@ import { createBaseEntity } from './gameEntity.js'
  * @property {boolean} showImprovements - Whether improvements section is expanded in UI
  * @property {boolean} showSuccesses - Whether successes section is expanded in UI
  * @property {Object.<string, boolean>} [improvements] - Map of improvement IDs to ownership status
+ * @property {number} [columnIndex] - Column index (0-2) in the three-column layout
+ * @property {string|null} [customGroupId] - ID of the custom group this ability belongs to
  */
 
 /**
@@ -103,7 +107,11 @@ import { createBaseEntity } from './gameEntity.js'
  * @property {ActiveEffect[]} activeEffects - Currently active effects
  * @property {boolean} groupAbilitiesBySource - Whether to group abilities by source
  * @property {boolean} groupAbilitiesByManaColor - Whether to group abilities by mana color
+ * @property {boolean} groupAbilitiesByCustom - Whether to group abilities by custom user-defined groups
  * @property {boolean} groupEquipmentBySource - Whether to group equipment by source
+ * @property {boolean} groupEquipmentByCustom - Whether to group equipment by custom user-defined groups
+ * @property {Array<{id: string, name: string}>} abilityCustomGroups - User-defined ability group definitions
+ * @property {Array<{id: string, name: string}>} equipmentCustomGroups - User-defined equipment group definitions
  * @property {string} abilitySortOption - Sort option for abilities
  * @property {string} equipmentSortOption - Sort option for equipment
  * @property {Object} autoCalculations - Auto-calculation settings

--- a/shared/types/entities/gameConcepts/ancestry.js
+++ b/shared/types/entities/gameConcepts/ancestry.js
@@ -1,7 +1,14 @@
 import { createDefaultGameConcept, ConceptType } from './gameConcept.js'
 
 /**
- * @typedef {import('./gameConcept.js').GameConcept} Ancestry
+ * @typedef {import('./gameConcept.js').GameConcept & {
+ *   heightMin: number,
+ *   heightMax: number,
+ *   weightMin: number,
+ *   weightMax: number,
+ *   lifespan: string,
+ *   speed: number,
+ * }} Ancestry
  */
 
 /**
@@ -9,5 +16,13 @@ import { createDefaultGameConcept, ConceptType } from './gameConcept.js'
  * @returns {Ancestry}
  */
 export function createDefaultAncestry() {
-  return createDefaultGameConcept(ConceptType.ANCESTRY)
+  return {
+    ...createDefaultGameConcept(ConceptType.ANCESTRY),
+    heightMin: 0,
+    heightMax: 0,
+    weightMin: 0,
+    weightMax: 0,
+    lifespan: '',
+    speed: 30,
+  }
 }


### PR DESCRIPTION
- Replaces MasonryGrid with ThreeColumnLayout and GroupedThreeColumnLayout, adding drag-to-reorder for abilities and equipment and a new "Custom" grouping mode with user-defined, renameable groups.
- Adds a CardPreviewOverlay singleton that shows the full expanded card on hover alongside a collapsed one, with viewport-aware positioning and drag suppression.
- Refactors CharacterSheet away from modal styling, and makes ConceptDetail full-screen instead of a modal.
- Removes a prop-drilling anti-pattern in EditEquipmentModal and fixes awkward card preview hover behavior.
- Adds a physiology section to ancestries with migrated data, sets image gallery limits to prevent excessive indicator dots, and suppresses a duplicate engagement message when no engagement dice are present.